### PR TITLE
feat: fix tests, update connexion for strict checking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ ignore=E266,W504,W503
 
 [aliases]
 test=pytest
+
+[tool:pytest]
+testpaths = subhub

--- a/subhub/app.py
+++ b/subhub/app.py
@@ -6,8 +6,10 @@ import os
 
 
 def create_app(config=None):
-    app = connexion.FlaskApp(__name__, specification_dir='')
-    app.add_api('subhub_api.yaml', pass_context_arg_name='request')
+    options = {"swagger_ui": False}
+    app = connexion.FlaskApp(__name__, specification_dir='./', options=options)
+    app.add_api('subhub_api.yaml', pass_context_arg_name='request',
+                strict_validation=True)
 
     CORS(app.app)
     return app

--- a/subhub/stripe_calls.py
+++ b/subhub/stripe_calls.py
@@ -28,6 +28,7 @@ def create_customer(source_token, fxa, email):
     except stripe.error.InvalidRequestError as e:
         return str(e)
 
+
 def subscribe_customer(customer, plan):
     """
     Subscribe Customer to Plan
@@ -89,6 +90,7 @@ def list_all_plans():
         stripe_plans.append({'plan_id': p['id'], 'product_id': p['product'], 'interval': p['interval'], 'amount': p['amount'], 'currency': p['currency']})
     return stripe_plans, 200
 
+
 def cancel_subscription(uid, sub_id):
     # TODO Remove payment source on cancel
     try:
@@ -113,6 +115,7 @@ def cancel_subscription(uid, sub_id):
     else:
         return 'Subscription not available.', 400
 
+
 def subscription_status(uid):
     if not isinstance(uid, str):
         return 'Invalid ID', 400
@@ -124,6 +127,7 @@ def subscription_status(uid):
     if subscriptions is None:
         return 'No subscriptions for this customer.', 404
     return subscriptions, 201
+
 
 def update_payment_method(uid, data):
     if not isinstance(data['pmt_token'], str):
@@ -148,6 +152,7 @@ def update_payment_method(uid, data):
 def fxa_customer_update(uid):
     print(f'customer update {uid}')
     return {"customer": uid}, 200
+
 
 def api_validation(api_token):
     if api_token is None:

--- a/subhub/subhub_api.yaml
+++ b/subhub/subhub_api.yaml
@@ -20,7 +20,7 @@ securityDefinitions:
       Ops issued token.
       An example of the Authorization header would be:
       ```Authorization: Bearer 00secret00```
-    x-apikeyInfoFunc: auth_validation.basic_auth
+    x-apikeyInfoFunc: subhub.auth_validation.basic_auth
 parameters:
   uidParam:
     in: path
@@ -37,13 +37,13 @@ parameters:
 paths:
   /customer/{uid}/subscriptions:
     get:
-      operationId: stripe_calls.subscription_status
+      operationId: subhub.stripe_calls.subscription_status
       tags:
         - Subscriptions
       summary: List of Subscriptions
       description: Get list of subscriptions for a premium payments customer
       produces:
-        - appliation/json;
+        - application/json
       security:
         - AuthApiKey: []
       responses:
@@ -58,13 +58,13 @@ paths:
       parameters:
         - $ref: '#/parameters/uidParam'
     post:
-      operationId: stripe_calls.subscribe_to_plan
+      operationId: subhub.stripe_calls.subscribe_to_plan
       tags:
         - Subscriptions
       summary: Subscribe to Plan
       description: Subscribe to a Mozilla Plan
       produces:
-        - application/json;
+        - application/json
       security:
         - AuthApiKey: []
       responses:
@@ -97,13 +97,13 @@ paths:
                 example: user@gmail.com
   /plans:
     get:
-      operationId: stripe_calls.list_all_plans
+      operationId: subhub.stripe_calls.list_all_plans
       tags:
         - Subscriptions
       summary: List all Stripe Plans
       description: List all plans available from subscription provider
       produces:
-        - appliation/json;
+        - application/json
       security:
         - AuthApiKey: []
       responses:
@@ -115,7 +115,7 @@ paths:
           description: Error missing parameter
   /customer/{uid}/subscriptions/{sub_id}:
     delete:
-      operationId: stripe_calls.cancel_subscription
+      operationId: subhub.stripe_calls.cancel_subscription
       tags:
         - Subscriptions
       summary: Cancel a Subscription
@@ -136,13 +136,13 @@ paths:
         - $ref: '#/parameters/subIdParam'
   /customer/{uid}:
     get:
-      operationId: stripe_calls.fxa_customer_update
+      operationId: subhub.stripe_calls.fxa_customer_update
       tags:
         - Subscriptions
       summary: Firefox Customer Update
       description: Get updated customer subscription data
       produces:
-        - application/json;
+        - application/json
       security:
         - AuthApiKey: []
       responses:
@@ -153,7 +153,7 @@ paths:
       parameters:
         - $ref: '#/parameters/uidParam'
     post:
-      operationId: stripe_calls.update_payment_method
+      operationId: subhub.stripe_calls.update_payment_method
       tags:
         - Subscriptions
       summary: Update Payment Method

--- a/subhub/tests/test_subhub.py
+++ b/subhub/tests/test_subhub.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
-from flask import Flask
 import connexion
 from subhub.app import create_app
+
 
 def test_subhub():
     '''


### PR DESCRIPTION
Loading the application failed as connexion expects the operationId to
be a fully resolvable function path. These have all been updated and
the test load succeeds.

Connexion setup no longer attempts to load the swagger_ui as that wasn't
compatible with the entire OpenAPI 2.0 spec.

Strict request validation is now enabled, and the request will be
rejected if the validation fails with the appropriate errors.