### PR TITLE
Enable Point-In-Time-Recovery (PITR) backups

### DIFF
--- a/services/fxa/serverless.yml
+++ b/services/fxa/serverless.yml
@@ -126,6 +126,8 @@ resources:
             AttributeName: userId
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
     Events:
       Type: 'AWS::DynamoDB::Table'
       Properties:
@@ -138,3 +140,5 @@ resources:
             AttributeName: eventId
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true


### PR DESCRIPTION
This change will enable Point-In-Time-Recovery backups. As described by the official [AWS documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html) PITR:

_Point-in-time recovery helps protect your Amazon DynamoDB tables from accidental write or delete operations. With point in time recovery, you don't have to worry about creating, maintaining, or scheduling on-demand backups. For example, suppose that a test script writes accidentally to a production DynamoDB table. With point-in-time recovery, you can restore that table to any point in time during the last 35 days. DynamoDB maintains incremental backups of your table._ 

I have tested this and it works as expected: when the change is deployed, it will modify the existing tables (without recreating them) to enable the backups. Once the table is deleted, a backup is generated automatically and will be retained for 35 days.
The price is based on GB stored for PITRs, while the backup created on deletion is free of cost. 

This solution is by far the simplest one I found. The only caveat is that is applied to all the Tables. There are other solutions involving creating custom Lambda functions triggering custom backups, on enabling PITR in tables using a regexp. While this is possible, I don't think is worth.

In order to prove that this change works, I've created a gist with the commands I follow for testing and validating the results. Please have a look at it: https://gist.github.com/The-smooth-operator/d3fec5db650d945b44ef934cfbe32493
