### PR TITLE
Update subhub_api.yaml: Added property to Plan schema

### DIFF
--- a/subhub/subhub_api.yaml
+++ b/subhub/subhub_api.yaml
@@ -348,6 +348,9 @@ definitions:
         product_id:
           type: string
           example: pro_basic
+        product_name:
+          type: string
+          example: Moz_Sub
         interval:
           type: string
           example: month


### PR DESCRIPTION
Added the product_name property to the Plan schema as defined in our yaml file to match what is returned via the API