### PR TITLE
Fix cancellation bug

### DIFF
--- a/subhub/api/payments.py
+++ b/subhub/api/payments.py
@@ -136,8 +136,6 @@ def cancel_subscription(uid, sub_id) -> FlaskResponse:
             stripe.Subscription.modify(sub_id, cancel_at_period_end=True)
             check_stripe_subscriptions(subscription_user.custId)
             return {"message": "Subscription cancellation successful"}, 201
-        else:
-            return {"message": "Subscription not available."}, 400
     return {"message": "Subscription not available."}, 400
 
 

--- a/subhub/tests/unit/test_payment_calls.py
+++ b/subhub/tests/unit/test_payment_calls.py
@@ -246,6 +246,90 @@ def test_cancel_subscription_with_valid_data(app, create_subscription_for_proces
     g.subhub_account.remove_from_db("process_test")
 
 
+def test_cancel_subscription_with_valid_data_multiple_subscriptions_remove_first():
+    """
+    GIVEN a user with multiple subscriptions
+    WHEN the first subscription is cancelled
+    THEN the specified subscription is cancelled
+    """
+    uid = uuid.uuid4()
+    subscription1, code1 = payments.subscribe_to_plan(
+        "valid_customer",
+        {
+            "pmt_token": "tok_visa",
+            "plan_id": "plan_EtMcOlFMNWW4nd",
+            "email": f"valid@{uid}customer.com",
+            "orig_system": "Test_system",
+        },
+    )
+    subscription2, code2 = payments.subscribe_to_plan(
+        "valid_customer",
+        {
+            "pmt_token": "tok_visa",
+            "plan_id": "plan_F4G9jB3x5i6Dpj",
+            "email": f"valid@{uid}customer.com",
+            "orig_system": "Test_system",
+        },
+    )
+
+    # cancel the first subscription created
+    (cancelled, code) = payments.cancel_subscription(
+        "valid_customer", subscription1["subscriptions"][0]["subscription_id"]
+    )
+    assert cancelled["message"] == "Subscription cancellation successful"
+    assert 201 == code
+
+    # clean up test data created
+    (cancelled, code) = payments.cancel_subscription(
+        "valid_customer", subscription2["subscriptions"][0]["subscription_id"]
+    )
+    g.subhub_account.remove_from_db("valid_customer")
+    assert cancelled["message"] == "Subscription cancellation successful"
+    assert 201 == code
+
+
+def test_cancel_subscription_with_valid_data_multiple_subscriptions_remove_second():
+    """
+    GIVEN a user with multiple subscriptions
+    WHEN the second subscription is cancelled
+    THEN the specified subscription is cancelled
+    """
+    uid = uuid.uuid4()
+    subscription1, code1 = payments.subscribe_to_plan(
+        "valid_customer",
+        {
+            "pmt_token": "tok_visa",
+            "plan_id": "plan_EtMcOlFMNWW4nd",
+            "email": f"valid@{uid}customer.com",
+            "orig_system": "Test_system",
+        },
+    )
+    subscription2, code2 = payments.subscribe_to_plan(
+        "valid_customer",
+        {
+            "pmt_token": "tok_visa",
+            "plan_id": "plan_F4G9jB3x5i6Dpj",
+            "email": f"valid@{uid}customer.com",
+            "orig_system": "Test_system",
+        },
+    )
+
+    # cancel the second subscription created
+    (cancelled, code) = payments.cancel_subscription(
+        "valid_customer", subscription2["subscriptions"][0]["subscription_id"]
+    )
+    assert cancelled["message"] == "Subscription cancellation successful"
+    assert 201 == code
+
+    # clean up test data created
+    (cancelled, code) = payments.cancel_subscription(
+        "valid_customer", subscription1["subscriptions"][0]["subscription_id"]
+    )
+    g.subhub_account.remove_from_db("valid_customer")
+    assert cancelled["message"] == "Subscription cancellation successful"
+    assert 201 == code
+
+
 def test_cancel_subscription_with_invalid_data(app, create_subscription_for_processing):
     (subscription, code) = create_subscription_for_processing
     (cancelled, code) = payments.cancel_subscription(


### PR DESCRIPTION
Updated cancel_subscription method to ensure that in the case of multiple subscriptions, that the loop would reach past the first instance when searching for the subscription to cancel

Added tests covering the multiple subscription cases - cancelling first and cancelling second