### PR TITLE
SS 231 reactivate subscription endpoint

### DIFF
--- a/subhub/subhub_api.yaml
+++ b/subhub/subhub_api.yaml
@@ -187,6 +187,38 @@ paths:
           schema:
             $ref: '#/definitions/Plans'
   /customer/{uid}/subscriptions/{sub_id}:
+    post:
+      operationId: subhub.api.payments.reactivate_subscription
+      tags:
+        - Subscriptions
+      summary: Reactivate a Subscription
+      description: Reactivate a subscription that's been cancelled but hasn't yet ended.
+      security:
+        - PayApiKey: []
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: Subscription already active
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+        '201':
+          description: Subscription reactivation successful
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+        '404':
+          description: Subscription or User could not be found
+          schema:
+            $ref: '#/definitions/Errormessage'
+      parameters:
+        - $ref: '#/parameters/uidParam'
+        - $ref: '#/parameters/subIdParam'
     delete:
       operationId: subhub.api.payments.cancel_subscription
       tags:
@@ -196,7 +228,7 @@ paths:
       security:
         - PayApiKey: []
       produces:
-        - application/json;
+        - application/json
       responses:
         '201':
           description: Subscription cancellation successful.

--- a/subhub/tests/unit/stripe/utils.py
+++ b/subhub/tests/unit/stripe/utils.py
@@ -25,3 +25,8 @@ class MockSqsClient:
 class MockSubhubAccount:
     def subhub_account(self):
         pass
+
+
+class MockSubhubUser:
+    id = None
+    custId = None


### PR DESCRIPTION
An endpoint has been added to allow for an active subscription that has been flagged for cancellation to have that flag removed, so that the subscription remains active.

- Endpoint added: POST /customer/{uid}/subscriptions/{sub_id}
- Swagger documentation for endpoint
- Unit tests covering the added functionality

https://jira.mozilla.com/browse/SS-231
https://github.com/mozilla/subhub/issues/68