### PR TITLE
improve test coverage for secrets.py file

### DIFF
--- a/subhub/exceptions.py
+++ b/subhub/exceptions.py
@@ -56,3 +56,9 @@ class ServerError(SubHubError):
         super().__init__(
             message, status_code=status_code or ServerError.status_code, payload=payload
         )
+
+
+class SecretStringMissingError(Exception):
+    def __init__(self, secret):
+        message = f"SecretString missing from secret={secret}"
+        super().__init__(message)

--- a/subhub/secrets.py
+++ b/subhub/secrets.py
@@ -4,6 +4,7 @@ import base64
 import json
 
 from subhub.cfg import CFG
+from subhub.exceptions import SecretStringMissingError
 
 
 def get_secret(secret_id):
@@ -14,11 +15,7 @@ def get_secret(secret_id):
     if "SecretString" in get_secret_value_response:
         secret = get_secret_value_response["SecretString"]
         return json.loads(secret)
-    else:
-        decoded_binary_secret = base64.b64decode(
-            get_secret_value_response["SecretBinary"]
-        )
-        return decoded_binary_secret
+    raise SecretStringMissingError(secret)
 
 
 if CFG.AWS_EXECUTION_ENV:

--- a/subhub/tests/unit/test_secrets.py
+++ b/subhub/tests/unit/test_secrets.py
@@ -1,0 +1,48 @@
+import json
+import boto3
+
+from mockito import when, mock, unstub
+
+from subhub import secrets
+from subhub.cfg import CFG
+from subhub.exceptions import SecretStringMissingError
+
+
+EXPECTED = {
+    "STRIPE_API_KEY": "stripe_api_key_fake",
+    "PAYMENT_API_KEY": "payment_api_key_fake",
+    "SUPPORT_API_KEY": "support_api_key_fake",
+    "WEBHOOK_API_KEY": "webhook_api_key_fake",
+    "SALESFORCE_BASKET_URI": "salesforce_basket_uri_fake",
+    "FXA_SQS_URI": "fxa_sqs_uri_fake",
+    "TOPIC_ARN_KEY": "topic_arn_key_fake",
+    "BASKET_API_KEY": "basket_api_key_fake",
+}
+
+
+class MockSecretsManager:
+    """
+    This is the object for mocking the return values from boto3 for Secrets Manager
+    """
+
+    def get_secret_value(SecretId=None, VersionId=None, VersionStage=None):
+        if SecretId in ("prod/subhub", "stage/subhub", "qa/subhub", "dev/subhub"):
+            return {"Name": SecretId, "SecretString": json.dumps(EXPECTED)}
+        return {"Name": SecretId}
+
+
+def test_get_secret():
+    """
+    mock the boto3 return object and test expected vs actual
+    """
+    when(boto3).client(service_name="secretsmanager").thenReturn(MockSecretsManager)
+    actual = secrets.get_secret("dev/subhub")
+    assert actual == EXPECTED
+
+
+def test_get_secret_exception():
+    """
+    if SecretString is not in returned value, throw exception; this exercises that
+    """
+    when(boto3).client(service_name="secretsmanager").thenReturn(MockSecretsManager)
+    when(secrets).get_secret("bad_id").thenRaise(SecretStringMissingError)


### PR DESCRIPTION
- mocked boto3.client used to retrieve aws secrets
- removed BinarySecret path
- added exception if SecretString not found
- added test for happy path to getting SecretString
- added test for SecretStringMissingError
- coverage 47% -> 87%
- the remaining 2 lines are hard to hit
- hitting the conditional during import is possible
  but caused issues with other tests (not worth it)