### PR TITLE
Tracing unit tests

### DIFF
--- a/subhub/tests/unit/test_tracing.py
+++ b/subhub/tests/unit/test_tracing.py
@@ -1,0 +1,42 @@
+import functools
+
+from subhub.tracing import timed, mprofiled
+from random import randint, randrange
+
+
+@timed
+def generate_random_value():
+    return randint(0, 9)
+
+
+@timed
+def generate_wrapped_random_value():
+    return __wrapped(randint(0, 9))
+
+
+@timed
+def __wrapped(functor):
+    @functools.wraps(functor)
+    def call(*args, **kwargs):
+        return functor(*args, **kwargs)
+
+    return call
+
+
+@mprofiled
+def generate_random_list():
+    return [randrange(1, 101, 1) for _ in range(10)]
+
+
+def test_timed():
+    assert type(generate_random_value()) is int
+
+
+def test_timed_wrapped():
+    assert type(generate_wrapped_random_value()) is int
+
+
+def test_mprofile():
+    collection = generate_random_list()
+    assert isinstance(collection, list)
+    assert isinstance(collection[0], int)

--- a/subhub/tracing.py
+++ b/subhub/tracing.py
@@ -1,3 +1,4 @@
+import functools
 import time
 import cProfile
 from subhub.cfg import CFG
@@ -76,12 +77,20 @@ Calling syntax;
 
 
 def timed(function):
+    from inspect import isfunction
+
     def timer(*args, **kwargs):
         if not CFG.PROFILING_ENABLED:
-            return function(*args, **kwargs)
+            result = function(*args, **kwargs)
+            if isfunction(result):
+                return result.__wrapped__
+            else:
+                return result
         else:
             start = time.time()
             result = function(*args, **kwargs)
+            if isfunction(result):
+                result = result.__wrapped__
             end = time.time()
             print(function.__name__, "took", end - start, "time")
             return result


### PR DESCRIPTION
This pull request (PR) provides unit test coverage for the tracing decorators that we added for profiling the code base.  This PR also has the fix for the case in which a wrapped object is returned from the connexion response as seen [here](https://github.com/zalando/connexion/blob/master/connexion/decorators/decorator.py#L45).  