### PR TITLE
Validate origin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # SubHub
-payment subscription REST api for customers:
+
+[![Build Status](https://travis-ci.org/mozilla/subhub.svg?branch=master)](https://travis-ci.org/mozilla/subhub)
+
+Payment subscription REST api for customers:
 - FxA (Firefox Accounts)
 
 ## Required Software

--- a/subhub/cfg.py
+++ b/subhub/cfg.py
@@ -377,6 +377,13 @@ class AutoConfigPlus(AutoConfig):  # pylint: disable=too-many-public-methods
         return self("NEW_RELIC_DISTRIBUTED_TRACING_ENABLED", True)
 
     @property
+    def ALLOWED_ORIGIN_SYSTEMS(self):
+        """
+        ALLOWED_ORIGIN_SYSTEMS
+        """
+        return self("ALLOWED_ORIGIN_SYSTEMS", "").split(",")
+
+    @property
     def PROFILING_ENABLED(self):
         """
         PROFILING_ENABLED

--- a/subhub/tests/conftest.py
+++ b/subhub/tests/conftest.py
@@ -35,6 +35,7 @@ def pytest_configure():
     os.environ["AWS_SECRET_ACCESS_KEY"] = "fake"
     os.environ["USER_TABLE"] = "users-testing"
     os.environ["EVENT_TABLE"] = "events-testing"
+    os.environ["ALLOWED_ORIGIN_SYSTEMS"] = "Test_system,Test_System,Test_System1"
     sys._called_from_test = True
 
     # Set stripe api key

--- a/subhub/tests/unit/test_cfg.py
+++ b/subhub/tests/unit/test_cfg.py
@@ -342,6 +342,13 @@ def test_NEW_RELIC_DISTRIBUTED_TRACING_ENABLED():
         assert False
 
 
+def test_ALLOWED_ORIGIN_SYSTEMS():
+    """
+    allowed origin systems
+    """
+    assert isinstance(CFG.ALLOWED_ORIGIN_SYSTEMS, list)
+
+
 def test_PROFILING_ENABLED():
     """
     profiling enabled

--- a/subhub/tests/unit/test_payment_calls.py
+++ b/subhub/tests/unit/test_payment_calls.py
@@ -1,17 +1,63 @@
+import os
 import uuid
-
 import pytest
 import stripe
-from stripe.error import InvalidRequestError
+
 from flask import g
+from stripe.error import InvalidRequestError
 from unittest.mock import Mock, MagicMock, PropertyMock
 
 from subhub.api import payments
-from subhub.customer import create_customer, subscribe_customer
+from subhub.customer import (
+    create_customer,
+    subscribe_customer,
+    existing_or_new_customer,
+)
 from subhub.tests.unit.stripe.utils import MockSubhubUser
 from subhub.log import get_logger
+from subhub.cfg import CFG
 
 logger = get_logger()
+
+
+def test_create_customer_invalid_origin_system():
+    """
+    GIVEN create a stripe customer
+    WHEN An invalid origin system is provided
+    THEN An exception should be raised
+    """
+    origin_system = "NOT_VALID"
+    with pytest.raises(InvalidRequestError) as request_error:
+        create_customer(
+            g.subhub_account,
+            user_id="test_mozilla",
+            source_token="tok_visa",
+            email="test_visa@tester.com",
+            origin_system=origin_system,
+            display_name="John Tester",
+        )
+    msg = f"origin_system={origin_system} not one of {CFG.ALLOWED_ORIGIN_SYSTEMS}"
+    assert msg == str(request_error.value)
+
+
+def test_existing_or_new_customer_invalid_origin_system():
+    """
+    GIVEN create a stripe customer
+    WHEN An invalid origin system is provided
+    THEN An exception should be raised
+    """
+    origin_system = "NOT_VALID"
+    with pytest.raises(InvalidRequestError) as request_error:
+        existing_or_new_customer(
+            g.subhub_account,
+            user_id="test_mozilla",
+            source_token="tok_visa",
+            email="test_visa@tester.com",
+            origin_system=origin_system,
+            display_name="John Tester",
+        )
+    msg = f"origin_system={origin_system} not one of {CFG.ALLOWED_ORIGIN_SYSTEMS}"
+    assert msg == str(request_error.value)
 
 
 def test_create_customer_tok_visa():


### PR DESCRIPTION
This pull request (PR) provides support to validate the origin system parameter in calls made to the API.  It will restrict such calls such that only configured calls are permitted origin_systems are permitted to be made.  The permitted origin_systems are stored in an AWS secret therefore this pull request requires an update thereof prior to deployment (dependency).  