### PR TITLE
Defect resolution in which the locustio package wasn't callable from …

### DIFF
--- a/automation_requirements.txt
+++ b/automation_requirements.txt
@@ -6,3 +6,4 @@ flake8==3.7.8
 tox==3.13.2
 black==19.3b0
 ruamel.yaml==0.15.97
+locustio==0.11.0


### PR DESCRIPTION
This pull request (PR) provides a defect resolution for the defect in which the relevant `doit` performance commands weren't callable from `doit` when the `locustio` package wasn't installed into the site-packages location prior to execution of the command.