### PR TITLE
Initial dependency graph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 - pip install -r automation_requirements.txt
 - npm install -g dynalite
 - npm install -g kinesalite
+- sudo apt-get install -y graphviz graphviz-dev
 script:
 - mkdir -p ~/.aws/
 - |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Payment subscription REST api for customers:
 ## Required Software
 - python3.7: requires python3.7 interpreter for creating virtual envionments for testing and running subhub
 - yarn (https://yarnpkg.com): package manager for node modules for setting up serverless for running and deploying subhub
+- cloc
+- [GraphViz](https://graphviz.org/)
 
 ## Important Environment Variables
 The CFG object is for accessing values either from the `subhub/.env` file and|or superceeded by env vars.
@@ -174,6 +176,18 @@ doit creds
 This run the `serverless deploy` command and requires the user to be logged into the AWS Account for `subhub`.
 ```
 doit deploy
+```
+
+## dependency graph
+This command will generate a GraphViz `dot` file that can be used to generate a media file.
+```
+doit graph
+```
+
+## dependency graph image 
+This command will generate a PNG of the dependency graph.
+```
+doit draw
 ```
 
 ## Postman

--- a/automation_requirements.txt
+++ b/automation_requirements.txt
@@ -7,4 +7,5 @@ tox==3.13.2
 black==19.3b0
 ruamel.yaml==0.15.97
 locustio==0.11.0
+doit-graph==0.1.1
 pyparsing==2.4.0

--- a/dodo.py
+++ b/dodo.py
@@ -108,6 +108,7 @@ def pyfiles(path, exclude=None):
     pyfiles = set(Path(path).rglob('*.py')) - set(Path(exclude).rglob('*.py') if exclude else [])
     return [pyfile.as_posix() for pyfile in pyfiles]
 
+# TODO: This needs to check for the existence of the dependency prior to execution or update project requirements.
 def task_count():
     '''
     use the cloc utility to count lines of code
@@ -678,6 +679,14 @@ def task_tidy():
             'rm -rf ' + ' '.join(TIDY_FILES),
             'find . | grep -E "(__pycache__|\.pyc$)" | xargs rm -rf',
         ],
+    }
+
+def task_draw():
+    """generate image from a dot file"""
+    return {
+        'file_dep': ['tasks.dot'],
+        'targets': ['tasks.png'],
+        'actions': ['dot -Tpng %(dependencies)s -o %(targets)s'],
     }
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request (PR) adds in initial support for dependency graphing with the `doit-graph` plug-in.  The `doit-graph` code base claims to be a plug-in but it doesn't load like other doit brethren.  This being said,  an [issue](https://github.com/pydoit/doit-graph/issues/7) was opened in their code base and once answered, I will port a solution over to this code base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/172)
<!-- Reviewable:end -->
