### PR TITLE
Lock pyparsing to 2.4.0

### DIFF
--- a/automation_requirements.txt
+++ b/automation_requirements.txt
@@ -7,3 +7,4 @@ tox==3.13.2
 black==19.3b0
 ruamel.yaml==0.15.97
 locustio==0.11.0
+pyparsing==2.4.0

--- a/subhub/tests/requirements.txt
+++ b/subhub/tests/requirements.txt
@@ -11,3 +11,4 @@ locustio==0.11.0
 purl==1.5
 behave==1.2.6
 jsoncompare==0.1.2
+pyparsing==2.4.0


### PR DESCRIPTION
This pull request (PR) locks the pyparsing version to 2.4.0 due to a defect that exhibits this behavior in the build server's build logs:

```
___________________________________ summary ____________________________________
  py37: commands succeeded
  congratulations :)
/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/packaging/requirements.py:57: UserWarning: warn_ungrouped_named_tokens_in_collection: setting results name 'specifier' on And expression collides with '_original_end' on contained expression
  VERSION_SPEC = originalTextFor(_VERSION_SPEC)("specifier")
/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/packaging/requirements.py:60: UserWarning: warn_ungrouped_named_tokens_in_collection: setting results name 'marker' on And expression collides with '_original_end' on contained expression
  MARKER_EXPR = originalTextFor(MARKER_EXPR())("marker")
The command "doit test" exited with 0.
```

From similar projects, it was found that this was traced down to pyparsing as observed [here](https://github.com/sdispater/poetry/issues/1244#issuecomment-514323367).  This also corresponds to a recent release made on July 24th, 2019 for that component as seen [here](https://pypi.org/project/pyparsing/#history).  

The downside to this implementation is that due to 2 dependencies that have unfixed dependency version tags, the latest will be taken so we have to lock it down in 2 locations per the `pipdeptree` analysis:

pytest (and others with dependencies) are called from the test module:
```
pytest-cov==2.7.1
  - coverage [required: >=4.4, installed: 4.5.3]
  - pytest [required: >=3.6, installed: 5.0.1]
    - atomicwrites [required: >=1.0, installed: 1.3.0]
    - attrs [required: >=17.4.0, installed: 19.1.0]
    - importlib-metadata [required: >=0.12, installed: 0.18]
      - zipp [required: >=0.5, installed: 0.5.2]
    - more-itertools [required: >=4.0.0, installed: 7.2.0]
    - packaging [required: Any, installed: 19.0]
      - pyparsing [required: >=2.0.2, installed: 2.4.1.1]```

tox is called from the automation (top-level) to leverage doit:
```
  tox==3.13.2
    - filelock [required: >=3.0.0,<4, installed: 3.0.12]
    - importlib-metadata [required: >=0.12,<1, installed: 0.18]
      - zipp [required: >=0.5, installed: 0.5.2]
    - packaging [required: >=14, installed: 19.0]
      - pyparsing [required: >=2.0.2, installed: 2.4.1.1]
```

This requires locked dependencies in both places.