### PR TITLE
Added simple lock around racy running subcall

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -10,6 +10,7 @@ import json
 import difflib
 import itertools
 import contextlib
+import threading
 
 from ruamel import yaml
 from functools import lru_cache
@@ -49,6 +50,8 @@ SVCS = [
     svc for svc in os.listdir('services')
     if os.path.isdir(f'services/{svc}') if os.path.isfile(f'services/{svc}/serverless.yml')
 ]
+
+mutex = threading.Lock()
 
 def envs(sep=' ', **kwargs):
     envs = dict(
@@ -386,15 +389,21 @@ def task_dynalite():
     cmd = f'{DYNALITE} --port {CFG.DYNALITE_PORT}'
     msg = f'dynalite server started on {CFG.DYNALITE_PORT} logging to {CFG.DYNALITE_FILE}'
     def running():
+        mutex.acquire()
         pid = None
         try:
             pid = call(f'lsof -i:{CFG.DYNALITE_PORT} -t')[1].strip()
         except CalledProcessError:
             return None
+        finally:
+            mutex.release()
+        mutex.acquire()
         try:
             args = call(f'ps -p {pid} -o args=')[1].strip()
         except CalledProcessError:
             return None
+        finally:
+            mutex.release()
         if cmd in args:
             return pid
         return None


### PR DESCRIPTION
This pull request (PR) provides an initial stab at reducing the racy behavior that was introduced (or existed) in the build system for this project.  This results in a behavior in which the command, `doit local` fails due to the build system believing that dynalite still exists and is running on port 8000 when a cursory inspection of this port shows no process presently holding open the process.  After much digging, it appears that this is the sub-call to see if the process is running.  An initial protection was added around this in the form of a simple mutual exclusion object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/181)
<!-- Reviewable:end -->
