### PR TITLE
Added symbolic link to subhub

### DIFF
--- a/services/missing-events/subhub
+++ b/services/missing-events/subhub
@@ -1,1 +1,1 @@
-/Users/mballard/PycharmProjects/subhub/subhub
+../../subhub


### PR DESCRIPTION
This pull request (PR) resolves the defect in which the prior symbolic link failed to resolve on other machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/190)
<!-- Reviewable:end -->
