### PR TITLE
DeletionPolicy:Retain in addition to PointInTimeRecovery

### DIFF
--- a/services/fxa/serverless.yml
+++ b/services/fxa/serverless.yml
@@ -240,6 +240,7 @@ resources:
           - Ref: SubHubSNS
     Users:
       Type: 'AWS::DynamoDB::Table'
+      DeletionPolicy: Retain
       Properties:
         AttributeDefinitions:
           -
@@ -254,6 +255,7 @@ resources:
           PointInTimeRecoveryEnabled: true
     DeletedUsers:
       Type: 'AWS::DynamoDB::Table'
+      DeletionPolicy: Retain
       Properties:
         AttributeDefinitions:
           - AttributeName: user_id
@@ -266,6 +268,7 @@ resources:
           PointInTimeRecoveryEnabled: true
     Events:
       Type: 'AWS::DynamoDB::Table'
+      DeletionPolicy: Retain
       Properties:
         AttributeDefinitions:
           -


### PR DESCRIPTION
This pull request (PR) came about in a moment of "where's my data" after doing a deployment (or 5).  I was running several performance tests at that time and noticed that some of my expected users were in fact, missing.

After perusing the AWS documentation, reference 1:

`If a resource has no DeletionPolicy attribute, AWS CloudFormation deletes the resource by default.`

Presently, `PointInTimeRecovery` is specified which minimizes data loss to within 5 minute increments per reference 2:

`LatestRestorableDateTime is typically 5 minutes before the current time.`

[AWS DeletionPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html)
[PointInTimeRecovery](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PointInTimeRecoveryDescription.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/209)
<!-- Reviewable:end -->
