### PR TITLE
Add negative cases for auth tokens for other auth providers

### DIFF
--- a/src/sub/tests/unit/test_authentication.py
+++ b/src/sub/tests/unit/test_authentication.py
@@ -63,10 +63,3 @@ def test_hub_auth_with_valid_support_token():
 def test_hub_auth_with_valid_payment_token():
     hub_auth = authentication.hub_auth("fake_payment_api_key", None)
     assert hub_auth is None
-
-# This should fail if tests are working
-
-
-def test_support_auth_insta_fail():
-    support_auth = authentication.support_auth("bad_hub_api_key", None)
-    assert support_auth["value"] is True


### PR DESCRIPTION
This PR helps to ensure that auth tokens for purpose X (support, payment, hub) cannot be used to auth against purpose Y (support, payment, hub), where X and Y can be any mismatch combination.