### PR TITLE
Make auth comparison less complex

### DIFF
--- a/src/shared/authentication.py
+++ b/src/shared/authentication.py
@@ -9,22 +9,27 @@ from shared.log import get_logger
 logger = get_logger()
 
 
-def payment_auth(api_token, required_scopes=None):
-    logger.info(f"api token {api_token}")
-    if api_token in (CFG.PAYMENT_API_KEY,):
+def test_token(test_api_token, cfg_api_token):
+    logger.info(f"test api token {test_api_token}")
+
+    # Make sure the config API token has a meaningful value set,
+    # to avoid an auth bypass on empty comparisons
+    if cfg_api_token in (None, "None", ""):
+        return None
+
+    if test_api_token == cfg_api_token:
         return {"value": True}
+
     return None
+
+
+def payment_auth(api_token, required_scopes=None):
+    return test_token(api_token, CFG.PAYMENT_API_KEY)
 
 
 def support_auth(api_token, required_scopes=None):
-    logger.info(f"api token {api_token}")
-    if api_token in (CFG.SUPPORT_API_KEY,):
-        return {"value": True}
-    return None
+    return test_token(api_token, CFG.SUPPORT_API_KEY)
 
 
 def hub_auth(api_token, required_scopes=None):
-    logger.info(f"api token {api_token}")
-    if api_token in (CFG.HUB_API_KEY,):
-        return {"value": True}
-    return None
+    return test_token(api_token, CFG.HUB_API_KEY)


### PR DESCRIPTION
When reviewing this code, I was a little worried about this auth pattern eventually happening if we cleaned this up later...

>>> "a" in "apple"
True
>>> "a" in ("apple",)
False

Meaning that if we drop the (,) part of the conditional just to simply down the line, we could create a future condition where an attacker would only need to substring match an API key to get successful auth.

This PR just makes the conditional logic as direct as it can be to ensure a true exact match.