### PR TITLE
Make Continuous Integration Runs Faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 dist: xenial
+cache:
+  directories:
+    - /home/travis/.nvm
+    - /home/travis/.cache/pip
 python:
   - "3.7"
-services:
-  - docker
 env:
   global:
     - BOTO_CONFIG: "/dev/null"


### PR DESCRIPTION
This pull request (PR) makes TravisCI builds faster on average by caching infrequently changing items (pip and nvm).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/264)
<!-- Reviewable:end -->
