### PR TITLE
Add anchors to repo_name regex

### DIFF
--- a/src/shared/cfg.py
+++ b/src/shared/cfg.py
@@ -203,7 +203,7 @@ class AutoConfigPlus(AutoConfig):  # pylint: disable=too-many-public-methods
         """
         repo_name
         """
-        pattern = r"((ssh|https)://)?(git@)?github.com[:/](?P<repo_name>[A-Za-z0-9\/\-_]+)(.git)?"
+        pattern = r"^((https|ssh)://)?(git@)?github.com[:/](?P<repo_name>[A-Za-z0-9\/\-_]+)(.git)?$"
         match = re.search(pattern, self.REMOTE_ORIGIN_URL)
         return match.group("repo_name")
 


### PR DESCRIPTION
Some additional notes here, just to show the regex overmatching on things it probably shouldn't...

https://gist.github.com/claudijd/3c89c22314ca4c7ec556a4c74d469aff