### PR TITLE
Remove SLS symlink

### DIFF
--- a/services/fxa/sls
+++ b/services/fxa/sls
@@ -1,1 +1,0 @@
-../../node_modules/serverless/bin/serverless


### PR DESCRIPTION
This pull request (PR) removes the sls symlink in the serverless directory.  This was a todo item buried in code after the next serverless version upgrade.  Additionally this symlink is not referenced in the [dodo.py](https://github.com/mozilla/subhub/blob/229bfdc27b168382f4de4a7b6914f58ec2b2d5b6/dodo.py#L45).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/283)
<!-- Reviewable:end -->
