### PR TITLE
COPS-739 Update server_stripe_error()

### DIFF
--- a/src/hub/app.py
+++ b/src/hub/app.py
@@ -31,7 +31,9 @@ def intermittent_stripe_error(e):
 def server_stripe_error(e):
     logger.error("server stripe error", error=e)
     return (
-        jsonify({"message": f"{e.user_message}", "params": None, "code": f"{e.code}"}),
+        jsonify(
+            {"message": "Internal Server Error", "params": None, "code": f"{e.code}"}
+        ),
         500,
     )
 

--- a/src/shared/vendor.py
+++ b/src/shared/vendor.py
@@ -267,7 +267,7 @@ def reactivate_stripe_subscription(
         IdempotencyError,
         StripeErrorWithParamCode,
     ) as e:
-        logger.error("cancel sub error", error=str(e))
+        logger.error("reactivate sub error", error=str(e))
         raise e
 
 

--- a/src/sub/app.py
+++ b/src/sub/app.py
@@ -59,7 +59,9 @@ def intermittent_stripe_error(e):
 def server_stripe_error(e):
     logger.error("server stripe error", error=e)
     return (
-        jsonify({"message": f"{e.user_message}", "params": None, "code": f"{e.code}"}),
+        jsonify(
+            {"message": "Internal Server Error", "params": None, "code": f"{e.code}"}
+        ),
         500,
     )
 

--- a/src/sub/tests/unit/test_app.py
+++ b/src/sub/tests/unit/test_app.py
@@ -26,7 +26,10 @@ def test_intermittent_stripe_error():
 
 
 def test_server_stripe_error():
-    expected = jsonify({"message": "something", "code": "500", "params": None}), 500
+    expected = (
+        jsonify({"message": "Internal Server Error", "code": "500", "params": None}),
+        500,
+    )
     error = AuthenticationError("something", code="500")
     actual = server_stripe_error(error)
     assert actual[0].json == expected[0].json

--- a/src/sub/tests/unit/test_vendor.py
+++ b/src/sub/tests/unit/test_vendor.py
@@ -5,7 +5,7 @@
 import pytest
 import stripe
 
-from stripe.error import APIError
+from stripe.error import APIError, APIConnectionError
 
 from sub.shared import vendor, utils
 


### PR DESCRIPTION
- Resolve leaky Stripe API Key
- Update related test
- test_vendor.py:84 change error to APIConnectionError