### PR TITLE
Allow invalid JSON to not be committed to the codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: v2.1.0
     hooks:
     -   id: check-added-large-files
+    -   id: check-json
     -   id: detect-private-key
     -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
@@ -16,20 +17,10 @@ repos:
           '--no-sort-keys',
         ]
     -   id: trailing-whitespace
--   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.4.0
-    hooks:
-    -   id: reorder-python-imports
-        args: [--py3-plus]
 -   repo: meta
     hooks:
     -   id: check-hooks-apply
     -   id: check-useless-excludes
--   repo: git@github.com:Yelp/detect-secrets
-    rev: v0.12.4
-    hooks:
-    -   id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
 # TODO: Enable in the future as we have issues to address.
 # -   repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
 #     sha: v1.0.3


### PR DESCRIPTION
This pull request (PR) removes the JSON check from `dodo.py` in favor of a `pre-commit` check.  This will prevent accidental addition of invalid JSON formatted files to the repository.  Additionally it removes 2 checks for the time being (detect-secrets, import re-ordering).  The reasons for this is that we require documentation for the initial setup for other developers and common issues.  I have this on my to-do list and will do it and re-enable shortly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/290)
<!-- Reviewable:end -->
