### PR TITLE
Defect: Remove Dynalite Dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
 # Available pre-commit hooks
 #   https://pre-commit.com/hooks.html
+default_language_version:
+  # force all unspecified python hooks to run python3
+  python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
@@ -7,9 +14,7 @@ repos:
     -   id: check-added-large-files
     -   id: check-json
     -   id: detect-private-key
-    -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
-    -   id: name-tests-test
     -   id: pretty-format-json
         args: [
           '--autofix',
@@ -17,6 +22,15 @@ repos:
           '--no-sort-keys',
         ]
     -   id: trailing-whitespace
+-   repo: meta
+    hooks:
+    -   id: check-hooks-apply
+    -   id: check-useless-excludes
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    -   id: black
+        language_version: python3.7
 -   repo: meta
     hooks:
     -   id: check-hooks-apply

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: python
 dist: xenial
 sudo: required
+services:
+  - docker
 python:
  - "3.7"
 addons:
   apt:
     sources: ['ubuntu-toolchain-r-test']
     packages: ['bash', 'coreutils', 'awscli']
+notifications:
+  email:
+    on_failure: change
+    on_success: never
 cache:
   directories:
     - /home/travis/.nvm
     - /home/travis/.cache/pip
+    - docker
 env:
   global:
     - BOTO_CONFIG: "/dev/null"
@@ -25,10 +32,13 @@ before_install:
   - npm install -g kinesalite
   - sudo apt-get install -y awscli
   - ./bin/aws-credentials.sh
+  - docker pull vitarn/dynalite
 
 jobs:
   include:
     - stage: Unit Tests
+#      before_script:
+#        - gzip -dc docker/dynalite.tar.gz | docker load
       script:
         # The below 2 TravisCI statements are a workaround for an issue in TravisCI which
         # is best described as "Large writes to stdout sometimes fail with "Resource temporarily unavailable".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - dynalite
 
   dynalite:
-    build: https://github.com/vitarn/docker-dynalite.git
+    image: vitarn/dynalite:latest
     ports:
       - 4567
 

--- a/dodo.py
+++ b/dodo.py
@@ -16,46 +16,40 @@ from pathlib import Path
 from pkg_resources import parse_version
 from os.path import join, dirname, realpath
 
-sys.path.insert(0, join(dirname(realpath(__file__)), 'src'))
+sys.path.insert(0, join(dirname(realpath(__file__)), "src"))
 
 from shared.cfg import CFG, call, CalledProcessError
 
-DOIT_CONFIG = {
-    'default_tasks': [
-        'pull',
-        'deploy',
-        'count'
-    ],
-    'verbosity': 2,
-}
+DOIT_CONFIG = {"default_tasks": ["pull", "deploy", "count"], "verbosity": 2}
 
-HEADER = '''
+HEADER = """
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-'''
+"""
 
-SPACE = ' '
-NEWLINE = '\n'
-VENV = f'{CFG.REPO_ROOT}/venv'
-PYTHON3 = f'{VENV}/bin/python3.7'
-PIP3 = f'{PYTHON3} -m pip'
-MYPY = f'{VENV}/bin/mypy'
-NODE_MODULES = f'{CFG.REPO_ROOT}/node_modules'
-SLS = f'{NODE_MODULES}/serverless/bin/serverless'
-DYNALITE = f'{NODE_MODULES}/.bin/dynalite'
+SPACE = " "
+NEWLINE = "\n"
+VENV = f"{CFG.REPO_ROOT}/venv"
+PYTHON3 = f"{VENV}/bin/python3.7"
+PIP3 = f"{PYTHON3} -m pip"
+MYPY = f"{VENV}/bin/mypy"
+NODE_MODULES = f"{CFG.REPO_ROOT}/node_modules"
+SLS = f"{NODE_MODULES}/serverless/bin/serverless"
 SVCS = [
-    svc for svc in os.listdir('services')
-    if os.path.isdir(f'services/{svc}') if os.path.isfile(f'services/{svc}/serverless.yml')
+    svc
+    for svc in os.listdir("services")
+    if os.path.isdir(f"services/{svc}")
+    if os.path.isfile(f"services/{svc}/serverless.yml")
 ]
 SRCS = [
-    src for src in os.listdir('src/')
-    if os.path.isdir(f'src/{src}') if src != 'shared'
+    src for src in os.listdir("src/") if os.path.isdir(f"src/{src}") if src != "shared"
 ]
 
 mutex = threading.Lock()
 
-def envs(sep=' ', **kwargs):
+
+def envs(sep=" ", **kwargs):
     envs = dict(
         BRANCH=CFG.BRANCH,
         DEPLOY_DOMAIN=CFG.DEPLOY_DOMAIN,
@@ -78,51 +72,66 @@ def envs(sep=' ', **kwargs):
         PROJECT_NAME=CFG.PROJECT_NAME,
         VERSION=CFG.VERSION,
     )
-    return sep.join([
-        f'{key}={value}' for key, value in sorted(dict(envs, **kwargs).items())
-    ])
+    return sep.join(
+        [f"{key}={value}" for key, value in sorted(dict(envs, **kwargs).items())]
+    )
+
 
 def globs(*patterns, **kwargs):
-    return itertools.chain.from_iterable(glob.iglob(pattern, **kwargs) for pattern in patterns)
+    return itertools.chain.from_iterable(
+        glob.iglob(pattern, **kwargs) for pattern in patterns
+    )
+
 
 def docstr_format(*args, **kwargs):
     def wrapper(func):
         func.__doc__ = func.__doc__.format(*args, **kwargs)
         return func
+
     return wrapper
+
 
 class UnknownPkgmgrError(Exception):
     def __init__(self):
-        super(UnknownPkgmgrError, self).__init__('unknown pkgmgr!')
+        super(UnknownPkgmgrError, self).__init__("unknown pkgmgr!")
+
 
 def check_hash(program):
     try:
-        call(f'hash {program}')
+        call(f"hash {program}")
         return True
     except CalledProcessError:
         return False
 
+
 def get_pkgmgr():
-    if check_hash('dpkg'):
-        return 'deb'
-    elif check_hash('rpm'):
-        return 'rpm'
-    elif check_hash('brew'):
-        return 'brew'
+    if check_hash("dpkg"):
+        return "deb"
+    elif check_hash("rpm"):
+        return "rpm"
+    elif check_hash("brew"):
+        return "brew"
     raise UnknownPkgmgrError
+
 
 def has_header(content):
     return content.startswith(HEADER.lstrip())
 
+
 def pyfiles(path, exclude=None):
-    pyfiles = set(Path(path).rglob('*.py')) - set(Path(exclude).rglob('*.py') if exclude else [])
+    pyfiles = set(Path(path).rglob("*.py")) - set(
+        Path(exclude).rglob("*.py") if exclude else []
+    )
     return [pyfile.as_posix() for pyfile in pyfiles]
 
+
 def load_serverless(svc):
-    return yaml.safe_load(open(f'services/{svc}/serverless.yml'))
+    return yaml.safe_load(open(f"services/{svc}/serverless.yml"))
+
 
 def get_svcs_to_funcs():
-    return {svc: list(load_serverless(svc)['functions'].keys()) for svc in SVCS}
+    return {svc: list(load_serverless(svc)["functions"].keys()) for svc in SVCS}
+
 
 def defaults(*args, **kwargs):
     results = [None] * len(kwargs)
@@ -136,597 +145,513 @@ def defaults(*args, **kwargs):
             results[i] = v
     return results
 
+
 def parameterized(dec):
     def layer(*args, **kwargs):
         def repl(f):
             return dec(f, *args, **kwargs)
+
         return repl
+
     layer.__name__ = dec.__name__
     layer.__doc__ = dec.__doc__
     return layer
+
 
 @parameterized
 def guard(func, env):
     def wrapper(*args, **kwargs):
         task_dict = func(*args, **kwargs)
-        if CFG.DEPLOYED_ENV == env and CFG('DEPLOY_TO', None) != env:
-            task_dict['actions'] = [
-                f'attempting to run {func.__name__} without env var DEPLOY_TO={env} set',
-                'false',
+        if CFG.DEPLOYED_ENV == env and CFG("DEPLOY_TO", None) != env:
+            task_dict["actions"] = [
+                f"attempting to run {func.__name__} without env var DEPLOY_TO={env} set",
+                "false",
             ]
         return task_dict
+
     wrapper.__name__ = func.__name__
     wrapper.__doc__ = func.__doc__
     return wrapper
+
 
 @parameterized
 def skip(func, taskname):
     def wrapper(*args, **kwargs):
         task_dict = func(*args, **kwargs)
-        envvar = f'SKIP_{taskname.upper()}'
+        envvar = f"SKIP_{taskname.upper()}"
         if CFG(envvar, None):
-            task_dict['uptodate'] = [True]
+            task_dict["uptodate"] = [True]
         return task_dict
+
     wrapper.__name__ = func.__name__
     wrapper.__doc__ = func.__doc__
     return wrapper
 
+
 def task_envs():
-    '''
+    """
     show which environment variabls will be used in package, deploy, etc
-    '''
-    return {
-        'task_dep': [
-            'check:noroot',
-        ],
-        'actions': [
-            lambda: print(envs('\n')),
-        ],
-    }
+    """
+    return {"task_dep": ["check:noroot"], "actions": [lambda: print(envs("\n"))]}
+
 
 def check_noroot():
-    '''
+    """
     make sure script isn't run as root
-    '''
+    """
     return {
-        'name': 'noroot',
-        'actions': [
-            'echo "DO NOT RUN AS ROOT!"',
-            'false',
-        ],
-        'uptodate': [
-            lambda: os.getuid() != 0,
-        ],
+        "name": "noroot",
+        "actions": ['echo "DO NOT RUN AS ROOT!"', "false"],
+        "uptodate": [lambda: os.getuid() != 0],
     }
 
+
 def gen_prog_check(name, program=None):
-    '''
+    """
     genereate program check
-    '''
+    """
     return {
-        'name': name,
-        'task_dep': [
-            'check:noroot',
-        ],
-        'actions': [
-            f'echo "required {name} not installed!"',
-            'false',
-        ],
-        'uptodate': [
-            lambda: check_hash(program or name)
-        ]
+        "name": name,
+        "task_dep": ["check:noroot"],
+        "actions": [f'echo "required {name} not installed!"', "false"],
+        "uptodate": [lambda: check_hash(program or name)],
     }
+
 
 def gen_file_check(name, func, *patterns, message=None):
     filenames = globs(*patterns, recursive=True)
+
     def load_test(func, filename):
         try:
             func(open(filename))
             return True
         except:
             return False
+
     @lru_cache(3)
     def failed_loads():
         return [filename for filename in filenames if not load_test(func, filename)]
+
     return {
-        'name': name,
-        'task_dep': [
-            'check:noroot',
-        ],
-        'actions': [
-            f'echo "{func.__module__}.{func.__name__} failed on {filename}"' for filename in failed_loads()
-        ] + [
-            f'echo "{message}"',
-            'false'
-        ] if len(failed_loads()) else [],
-        'uptodate': [
-            lambda: len(failed_loads()) == 0,
+        "name": name,
+        "task_dep": ["check:noroot"],
+        "actions": [
+            f'echo "{func.__module__}.{func.__name__} failed on {filename}"'
+            for filename in failed_loads()
         ]
+        + [f'echo "{message}"', "false"]
+        if len(failed_loads())
+        else [],
+        "uptodate": [lambda: len(failed_loads()) == 0],
     }
+
 
 def check_black():
-    '''
+    """
     run black --check in src/ directory
-    '''
-    black_check = f'black --check src/'
+    """
+    black_check = f"black --check src/"
     return {
-        'name': 'black',
-        'task_dep': [
-            'check:noroot',
+        "name": "black",
+        "task_dep": ["check:noroot"],
+        "actions": [
+            f"{black_check} || echo \"consider running 'doit black'\"",
+            "false",
         ],
-        'actions': [
-            f'{black_check} || echo "consider running \'doit black\'"',
-            'false',
-        ],
-        'uptodate': [
-            black_check,
-        ]
+        "uptodate": [black_check],
     }
 
+
 def check_reqs():
-    '''
+    """
     check requirements
-    '''
-    installed = call('python3 -m pip freeze')[1].strip().split('\n')
-    installed = [tuple(item.split('==')) for item  in installed if '==' in item]
-    required = [line for line in open('automation_requirements.txt').read().strip().split('\n') if not line.startswith('#')]
-    required = [tuple(item.split('==')) if '==' in item else (item, None) for item in required]
+    """
+    installed = call("python3 -m pip freeze")[1].strip().split("\n")
+    installed = [tuple(item.split("==")) for item in installed if "==" in item]
+    required = [
+        line
+        for line in open("automation_requirements.txt").read().strip().split("\n")
+        if not line.startswith("#")
+    ]
+    required = [
+        tuple(item.split("==")) if "==" in item else (item, None) for item in required
+    ]
+
     @lru_cache(3)
     def check():
         def match_one(iname, iver, rname, rver=None):
-            return (iname == rname and parse_version(iver) >= parse_version(rver or iver))
+            return iname == rname and parse_version(iver) >= parse_version(rver or iver)
+
         def match_any(installed, rname, rver):
-            return any([match_one(iname, iver, rname, rver) for iname, iver in installed])
-        return [(rname, rver) for rname, rver in required if not match_any(installed, rname, rver)]
+            return any(
+                [match_one(iname, iver, rname, rver) for iname, iver in installed]
+            )
+
+        return [
+            (rname, rver)
+            for rname, rver in required
+            if not match_any(installed, rname, rver)
+        ]
+
     def report(rname, rver):
-        version = f'or at version {rver}' if rver else ''
+        version = f"or at version {rver}" if rver else ""
         return f'echo "-> {rname} is not installed {version}"'
+
     return {
-        'name': 'reqs',
-        'task_dep': [
-            'check:noroot',
-        ],
-        'actions': [
-            report(rname, rver) for rname, rver in check()
-        ] + [
-            'echo "consider running \'./dodo.py\' or \'sudo pip install -r automation_requirements.txt\'"',
-            'false',
-        ] if len(check()) else [],
-        'uptodate': [
-            lambda: len(check()) == 0,
-        ],
+        "name": "reqs",
+        "task_dep": ["check:noroot"],
+        "actions": [report(rname, rver) for rname, rver in check()]
+        + [
+            "echo \"consider running './dodo.py' or 'sudo pip install -r automation_requirements.txt'\"",
+            "false",
+        ]
+        if len(check())
+        else [],
+        "uptodate": [lambda: len(check()) == 0],
     }
+
 
 def check_header(f):
     content = f.read()
     if has_header(content):
         return
-    msg = f'filename={f.name} does contain header; consider running doit header:{f.name}'
+    msg = (
+        f"filename={f.name} does contain header; consider running doit header:{f.name}"
+    )
     raise Exception(msg)
 
+
 def task_check():
-    '''
+    """
     checks: noroot, python3.7, yarn, awscli, json, yaml, black, reqs
-    '''
+    """
     yield check_noroot()
-    yield gen_prog_check('python3.7')
-    yield gen_prog_check('yarn')
-    yield gen_prog_check('docker-compose')
-    if not CFG('TRAVIS', None):
-        yield gen_prog_check('awscli', 'aws')
-    yield gen_file_check('json', json.load, 'services/**/*.json')
-    yield gen_file_check('yaml', yaml.safe_load, 'services/**/*.yaml', 'services/**/*.yml')
+    yield gen_prog_check("python3.7")
+    yield gen_prog_check("yarn")
+    yield gen_prog_check("docker-compose")
+    if not CFG("TRAVIS", None):
+        yield gen_prog_check("awscli", "aws")
+    yield gen_file_check("json", json.load, "services/**/*.json")
+    yield gen_file_check(
+        "yaml", yaml.safe_load, "services/**/*.yaml", "services/**/*.yml"
+    )
     header_message = "consider running 'doit header:<filename>'"
-    yield gen_file_check('header', check_header, 'src/**/*.py', message=header_message)
+    yield gen_file_check("header", check_header, "src/**/*.py", message=header_message)
     yield check_black()
     yield check_reqs()
 
+
 def task_creds():
-    '''
+    """
     check for valid aws credentials
-    '''
+    """
+
     def creds_check():
         try:
-            call('aws sts get-caller-identity')
+            call("aws sts get-caller-identity")
             return True
         except CalledProcessError:
             return False
+
     return {
-        'task_dep': [
-            'check',
-        ],
-        'actions': [
-            'echo "missing valid AWS credentials"',
-            'false',
-        ],
-        'uptodate': [
-            creds_check
-        ],
+        "task_dep": ["check"],
+        "actions": ['echo "missing valid AWS credentials"', "false"],
+        "uptodate": [creds_check],
     }
+
 
 def task_black():
-    '''
+    """
     run black on src/
-    '''
-    return {
-        'actions': [
-            f'black src/'
-        ],
-    }
+    """
+    return {"actions": [f"black src/"]}
+
 
 def task_header():
-    '''
+    """
     apply the HEADER to all the py files under src/
-    '''
+    """
+
     def ensure_headers():
-        for pyfile in pyfiles('src/'):
-            with open(pyfile, 'r') as old:
+        for pyfile in pyfiles("src/"):
+            with open(pyfile, "r") as old:
                 content = old.read()
                 if has_header(content):
                     continue
-                with open(f'{pyfile}.new', 'w') as new:
+                with open(f"{pyfile}.new", "w") as new:
                     new.write(HEADER.lstrip())
-                    new.write('\n')
+                    new.write("\n")
                     new.write(content.lstrip())
-                    os.rename(f'{pyfile}.new', pyfile)
-    return {
-        'actions': [
-            ensure_headers,
-        ],
-    }
+                    os.rename(f"{pyfile}.new", pyfile)
 
-@skip('venv')
+    return {"actions": [ensure_headers]}
+
+
+@skip("venv")
 def task_venv():
-    '''
+    """
     setup virtual env
-    '''
-    app_requirements = f'src/app_requirements.txt'
-    test_requirements = f'src/test_requirements.txt'
+    """
+    app_requirements = f"src/app_requirements.txt"
+    test_requirements = f"src/test_requirements.txt"
     return {
-        'task_dep': [
-            'check',
-        ],
-        'actions': [
-            f'$(which python3.7) -m venv {VENV}',
-            f'{PIP3} install --upgrade pip',
+        "task_dep": ["check"],
+        "actions": [
+            f"$(which python3.7) -m venv {VENV}",
+            f"{PIP3} install --upgrade pip",
             f'[ -f "{app_requirements}" ] && {PIP3} install -r "{app_requirements}"',
             f'[ -f "{test_requirements}" ] && {PIP3} install -r "{test_requirements}"',
         ],
     }
 
-def task_dynalite():
-    '''
-    dynalite db for testing and local runs: start, stop
-    '''
-    cmd = f'{DYNALITE} --port {CFG.DYNALITE_PORT}'
-    msg = f'dynalite server started on {CFG.DYNALITE_PORT} logging to {CFG.DYNALITE_FILE}'
-    def running():
-        mutex.acquire()
-        pid = None
-        try:
-            pid = call(f'lsof -i:{CFG.DYNALITE_PORT} -t')[1].strip()
-        except CalledProcessError:
-            return None
-        finally:
-            mutex.release()
-        mutex.acquire()
-        try:
-            args = call(f'ps -p {pid} -o args=')[1].strip()
-        except CalledProcessError:
-            return None
-        finally:
-            mutex.release()
-        if cmd in args:
-            return pid
-        return None
-    yield {
-        'name': 'stop',
-        'task_dep': [
-            'check',
-            'yarn',
-        ],
-        'actions': [
-            f'kill {running()}',
-        ],
-        'uptodate': [
-            lambda: running() is None
-        ],
-    }
-    yield {
-        'name': 'start',
-        'task_dep': [
-            'check',
-            'yarn',
-            'dynalite:stop',
-        ],
-        'actions': [
-            LongRunning(f'nohup {cmd} > {CFG.DYNALITE_FILE} &'),
-            f'echo "{msg}"',
-        ],
-        'uptodate': [
-            lambda: running(),
-        ],
-    }
 
 def task_local():
-    '''
+    """
     run local deployment
-    '''
+    """
     return {
-        'task_dep': [
-            'check',
-            'tar'
-        ],
-        'actions': [
-            f'env {envs()} docker-compose up --build'
-        ],
+        "task_dep": ["check", "tar"],
+        "actions": [f"env {envs()} docker-compose up --build"],
     }
 
+
 def task_yarn():
-    '''
-    Install packages from package.json into the node_modules directory.  Yarn will attempt 
-    on non-OSX operating systems to check/attempt to install fsevents. 
+    """
+    Install packages from package.json into the node_modules directory.  Yarn will attempt
+    on non-OSX operating systems to check/attempt to install fsevents.
     This is evidenced in the log files by the messages:
         info fsevents@2.0.7: The platform "linux" is incompatible with this module.
         info "fsevents@2.0.7" is an optional dependency and failed compatibility check. Excluding it from installation.
     Reference:
         1. [Filter out fsevents warning/info on non supported OS messages](https://github.com/yarnpkg/yarn/issues/2564)
         2. [Don't warn about incompatible optional dependencies](https://github.com/yarnpkg/yarn/issues/3738)
-    '''
+    """
     return {
-        'task_dep': [
-            'check',
-        ],
-        'actions': [
-            '[ -d node_modules/ ] && rm -rf node_modules/ || true',
-            'yarn install',
+        "task_dep": ["check"],
+        "actions": [
+            "[ -d node_modules/ ] && rm -rf node_modules/ || true",
+            "yarn install",
         ],
     }
+
 
 def task_perf_local():
-    '''
+    """
     run locustio performance tests on local deployment
-    '''
-    FLASK_PORT=5000
-    ENVS=envs(
+    """
+    FLASK_PORT = 5000
+    ENVS = envs(
         LOCAL_FLASK_PORT=FLASK_PORT,
-        AWS_ACCESS_KEY_ID='fake-id',
-        AWS_SECRET_ACCESS_KEY='fake-key',
-        PYTHONPATH='.'
+        AWS_ACCESS_KEY_ID="fake-id",
+        AWS_SECRET_ACCESS_KEY="fake-key",
+        PYTHONPATH=".",
     )
-    cmd = f'env {ENVS} {PYTHON3} src/sub/app.py' #FIXME: should work on hub too...
+    cmd = f"env {ENVS} {PYTHON3} src/sub/app.py"  # FIXME: should work on hub too...
     return {
-        'basename': 'perf-local',
-        'task_dep':[
-            'check',
-            'venv',
-            'dynalite:start'
+        "basename": "perf-local",
+        "task_dep": ["check", "venv"],
+        "actions": [
+            f"{PYTHON3} -m setup develop",
+            "echo $PATH",
+            LongRunning(
+                f"nohup env {envs} {PYTHON3} src/sub/app.py > /dev/null &"
+            ),  # FIXME: same as above
+            f"cd src/sub/tests/performance && locust -f locustfile.py --host=http://localhost:{FLASK_PORT}",  # FIXME: same
         ],
-        'actions':[
-            f'{PYTHON3} -m setup develop',
-            'echo $PATH',
-            LongRunning(f'nohup env {envs} {PYTHON3} src/sub/app.py > /dev/null &'), #FIXME: same as above
-            f'cd src/sub/tests/performance && locust -f locustfile.py --host=http://localhost:{FLASK_PORT}' #FIXME: same
-        ]
     }
+
 
 def task_perf_remote():
-    '''
+    """
     run locustio performance tests on remote deployment
-    '''
+    """
     return {
-        'basename': 'perf-remote',
-        'task_dep':[
-            'check',
-            'venv',
+        "basename": "perf-remote",
+        "task_dep": ["check", "venv"],
+        "actions": [
+            f"{PYTHON3} -m setup develop",
+            f"cd src/sub/tests/performance && locust -f locustfile.py --host=https://{CFG.DEPLOY_DOMAIN}",  # FIXME: same as above
         ],
-        'actions':[
-            f'{PYTHON3} -m setup develop',
-            f'cd src/sub/tests/performance && locust -f locustfile.py --host=https://{CFG.DEPLOY_DOMAIN}' #FIXME: same as above
-        ]
     }
 
-@skip('mypy')
+
+@skip("mypy")
 def task_mypy():
-    '''
+    """
     run mpyp, a static type checker for Python 3
-    '''
-    for pkg in ('sub', 'hub'):
+    """
+    for pkg in ("sub", "hub"):
         yield {
-            'name': pkg,
-            'task_dep': [
-                'check',
-                'yarn',
-                'venv',
-            ],
-            'actions': [
-                f'cd {CFG.REPO_ROOT}/src && env {envs(MYPYPATH=VENV)} {MYPY} -p {pkg}',
+            "name": pkg,
+            "task_dep": ["check", "yarn", "venv"],
+            "actions": [
+                f"cd {CFG.REPO_ROOT}/src && env {envs(MYPYPATH=VENV)} {MYPY} -p {pkg}"
             ],
         }
 
-@skip('test')
+
+@skip("test")
 def task_test():
-    '''
+    """
     run tox in tests/
-    '''
+    """
     return {
-        'task_dep': [
-            'check',
-            'yarn',
-            'venv',
-            'dynalite:stop',
+        "task_dep": [
+            "check",
+            "yarn",
+            "venv",
             #'mypy', FIXME: this needs to be activated once mypy is figured out
         ],
-        'actions': [
-            f'cd {CFG.REPO_ROOT} && tox',
-        ],
+        "actions": [f"cd {CFG.REPO_ROOT} && tox"],
     }
 
+
 def task_pytest():
-    '''
+    """
     run pytest per test file
-    '''
-    for filename in Path('src/sub/tests').glob('**/*.py'): #FIXME: should work on hub too...
+    """
+    for filename in Path("src/sub/tests").glob(
+        "**/*.py"
+    ):  # FIXME: should work on hub too...
         yield {
-            'name': filename,
-            'task_dep': [
-                'check',
-                'yarn',
-                'venv',
-                'dynalite:stop',
-            ],
-            'actions': [
-                f'{PYTHON3} -m pytest {filename} --disable-warnings -vxs',
-            ],
+            "name": filename,
+            "task_dep": ["check", "yarn", "venv"],
+            "actions": [f"{PYTHON3} -m pytest {filename} --disable-warnings -vxs"],
         }
+
 
 def task_package():
-    '''
+    """
     run serverless package -v for every service
-    '''
+    """
     for svc in SVCS:
         yield {
-            'name': svc,
-            'task_dep': [
-                'check',
-                'yarn',
-                'test',
-            ],
-            'actions': [
-                f'cd services/{svc} && env {envs()} {SLS} package --stage {CFG.DEPLOYED_ENV} -v',
+            "name": svc,
+            "task_dep": ["check", "yarn", "test"],
+            "actions": [
+                f"cd services/{svc} && env {envs()} {SLS} package --stage {CFG.DEPLOYED_ENV} -v"
             ],
         }
 
+
 def task_tar():
-    '''
+    """
     tar up source files, dereferncing symlinks
-    '''
-    excludes = ' '.join([
-        f'--exclude={CFG.SRCTAR}',
-        '--exclude=__pycache__',
-        '--exclude=*.pyc',
-        '--exclude=.env',
-        '--exclude=sub/tests',
-        '--exclude=hub/tests',
-        '--exclude=shared/tests',
-        '--exclude=.git'
-    ])
+    """
+    excludes = " ".join(
+        [
+            f"--exclude={CFG.SRCTAR}",
+            "--exclude=__pycache__",
+            "--exclude=*.pyc",
+            "--exclude=.env",
+            "--exclude=sub/tests",
+            "--exclude=hub/tests",
+            "--exclude=shared/tests",
+            "--exclude=.git",
+        ]
+    )
     for src in SRCS:
         ## it is important to note that this is required to keep the tarballs from
         ## genereating different checksums and therefore different layers in docker
         cmd = f'cd {CFG.REPO_ROOT}/src/{src} && echo "$(git status -s)" > {CFG.REVISION} && tar cvh {excludes} . | gzip -n > {CFG.SRCTAR} && rm {CFG.REVISION}'
         yield {
-            'name': src,
-            'task_dep': [
-                'check:noroot',
-            ],
-            'actions': [
-                f'echo "{cmd}"',
-                f'{cmd}',
-            ],
+            "name": src,
+            "task_dep": ["check:noroot"],
+            "actions": [f'echo "{cmd}"', f"{cmd}"],
         }
 
-@guard('prod')
+
+@guard("prod")
 def task_deploy():
-    '''
+    """
     deploy <svc> [<func>]
-    '''
+    """
+
     def deploy(args):
-        svc, func = defaults(*args, svc='fxa', func=None)
-        assert svc in SVCS, f'{svc} is not a valid service in {SVCS}'
+        svc, func = defaults(*args, svc="fxa", func=None)
+        assert svc in SVCS, f"{svc} is not a valid service in {SVCS}"
         if func:
             funcs = get_svcs_to_funcs()[svc]
-            assert func in funcs, f'{func} is not a valid function in {funcs}'
+            assert func in funcs, f"{func} is not a valid function in {funcs}"
         if func:
-            deploy_cmd = f'cd services/{svc} && env {envs()} {SLS} deploy function --stage {CFG.DEPLOYED_ENV} --aws-s3-accelerate -v --function {func}'
+            deploy_cmd = f"cd services/{svc} && env {envs()} {SLS} deploy function --stage {CFG.DEPLOYED_ENV} --aws-s3-accelerate -v --function {func}"
         else:
-            deploy_cmd = f'cd services/{svc} && env {envs()} {SLS} deploy --stage {CFG.DEPLOYED_ENV} --aws-s3-accelerate -v'
+            deploy_cmd = f"cd services/{svc} && env {envs()} {SLS} deploy --stage {CFG.DEPLOYED_ENV} --aws-s3-accelerate -v"
         call(deploy_cmd, stdout=None, stderr=None)
+
     return {
-        'task_dep': [
-            'check',
-            'creds',
-            'yarn',
-            'test',
-        ],
-        'pos_arg': 'args',
-        'actions': [(deploy,)],
+        "task_dep": ["check", "creds", "yarn", "test"],
+        "pos_arg": "args",
+        "actions": [(deploy,)],
     }
 
-@guard('prod')
+
+@guard("prod")
 def task_domain():
-    '''
+    """
     domain <svc> [create|delete]
-    '''
+    """
+
     def domain(args):
-        svc, action = defaults(svc='fxa', action=None)
-        assert action in ('create', 'delete'), "provide 'create' or 'delete'"
-        domain_cmd = f'cd services/{svc} && env {envs()} {SLS} {action}_domain --stage {CFG.DEPLOYED_ENV} -v'
+        svc, action = defaults(svc="fxa", action=None)
+        assert action in ("create", "delete"), "provide 'create' or 'delete'"
+        domain_cmd = f"cd services/{svc} && env {envs()} {SLS} {action}_domain --stage {CFG.DEPLOYED_ENV} -v"
         call(domain_cmd, stdout=None, stderr=None)
+
     return {
-        'task_dep': [
-            'check',
-            'creds',
-            'yarn',
-        ],
-        'pos_arg': 'args',
-        'actions': [(domain,)],
+        "task_dep": ["check", "creds", "yarn"],
+        "pos_arg": "args",
+        "actions": [(domain,)],
     }
+
 
 def task_remove():
-    '''
+    """
     run serverless remove -v for every service
-    '''
+    """
     for svc in SVCS:
-        servicepath = f'services/{svc}'
+        servicepath = f"services/{svc}"
         yield {
-            'name': svc,
-            'task_dep': [
-                'check',
-                'creds',
-                'yarn',
-            ],
-            'actions': [
-                f'cd {servicepath} && env {envs()} {SLS} remove -v',
-            ],
+            "name": svc,
+            "task_dep": ["check", "creds", "yarn"],
+            "actions": [f"cd {servicepath} && env {envs()} {SLS} remove -v"],
         }
 
+
 def task_pip3list():
-    '''
+    """
     venv/bin/pip3.7 list
-    '''
-    return {
-        'task_dep': [
-            'venv',
-        ],
-        'actions': [
-            f'{PIP3} list',
-        ],
-    }
+    """
+    return {"task_dep": ["venv"], "actions": [f"{PIP3} list"]}
+
 
 def task_curl():
-    '''
+    """
     curl again remote deployment url: /version, /deployed
-    '''
+    """
+
     def curl(args):
-        svc, func = defaults(*args, svc='fxa', func=None)
-        assert svc in SVCS, f'{svc} is not a valid service in {SVCS}'
-        funcs = [func] if func else [func for func in get_svcs_to_funcs()[svc] if func != 'mia']
+        svc, func = defaults(*args, svc="fxa", func=None)
+        assert svc in SVCS, f"{svc} is not a valid service in {SVCS}"
+        funcs = (
+            [func]
+            if func
+            else [func for func in get_svcs_to_funcs()[svc] if func != "mia"]
+        )
         for func in funcs:
-            for route in ('version', 'deployed'):
-                cmd = f'curl --silent https://{CFG.DEPLOYED_ENV}.{svc}.mozilla-subhub.app/v1/{func}/{route}'
+            for route in ("version", "deployed"):
+                cmd = f"curl --silent https://{CFG.DEPLOYED_ENV}.{svc}.mozilla-subhub.app/v1/{func}/{route}"
                 call(f'echo "{cmd}"; {cmd}', stdout=None, stderr=None)
-    return {
-        'pos_arg': 'args',
-        'actions': [(curl,)],
-    }
+
+    return {"pos_arg": "args", "actions": [(curl,)]}
+
 
 def task_rmrf():
-    '''
+    """
     delete cached files: pycache, pytest, node, venv, doitdb
-    '''
+    """
     rmrf = 'rm -rf "{}" \;'
-    spec = '''
+    spec = """
     pycache:
         __pycache__: d
         '*.pyc': d
@@ -740,28 +665,25 @@ def task_rmrf():
         venv: d
     doitdb:
         .doit.db: f
-    '''
+    """
     for name, targets in yaml.safe_load(spec).items():
         yield {
-            'name': name,
-            'actions': [
-                f'sudo find {CFG.REPO_ROOT} -depth -name {name} -type {type} -exec {rmrf}'
+            "name": name,
+            "actions": [
+                f"sudo find {CFG.REPO_ROOT} -depth -name {name} -type {type} -exec {rmrf}"
                 for name, type in targets.items()
             ],
         }
 
+
 def task_tidy():
-    '''
+    """
     delete cached files
-    '''
-    TIDY_FILES = [
-        '.doit.db',
-        'venv/',
-        '.pytest_cache/',
-    ]
+    """
+    TIDY_FILES = [".doit.db", "venv/", ".pytest_cache/"]
     return {
-        'actions': [
-            'rm -rf ' + ' '.join(TIDY_FILES),
+        "actions": [
+            "rm -rf " + " ".join(TIDY_FILES),
             'find . | grep -E "(__pycache__|\.pyc$)" | xargs rm -rf',
-        ],
+        ]
     }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,21 @@
 {
-  "description": "automation tools for running locally and deploying to aws",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mozilla/subhub"
-  },
-  "license": "MPL-2.0",
-  "devDependencies": {
-    "@hapi/hoek": "8.2.4",
-    "dynalite": "3.0.0",
-    "serverless": "1.53.0",
-    "serverless-domain-manager": "3.3.0",
-    "serverless-dynamodb-local": "0.2.38",
-    "serverless-offline": "5.11.0",
-    "serverless-package-external": "1.1.1",
-    "serverless-plugin-aws-alerts": "1.4.0",
-    "serverless-plugin-canary-deployments": "0.4.8",
-    "serverless-plugin-tracing": "2.0.0",
-    "serverless-python-requirements": "5.0.0",
-    "serverless-wsgi": "1.7.3"
-  }
+    "description": "automation tools for running locally and deploying to aws",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mozilla/subhub"
+    },
+    "license": "MPL-2.0",
+    "devDependencies": {
+        "@hapi/hoek": "8.2.4",
+        "serverless": "1.53.0",
+        "serverless-domain-manager": "3.3.0",
+        "serverless-dynamodb-local": "0.2.38",
+        "serverless-offline": "5.11.0",
+        "serverless-package-external": "1.1.1",
+        "serverless-plugin-aws-alerts": "1.4.0",
+        "serverless-plugin-canary-deployments": "0.4.8",
+        "serverless-plugin-tracing": "2.0.0",
+        "serverless-python-requirements": "5.0.0",
+        "serverless-wsgi": "1.7.3"
+    }
 }

--- a/src/hub/app.py
+++ b/src/hub/app.py
@@ -57,24 +57,20 @@ def server_stripe_card_error(e):
     return jsonify({"message": f"{e.user_message}", "code": f"{e.code}"}), 402
 
 
-def is_container() -> bool:
-    import requests
-
-    try:
-        requests.get(f"http://dynalite:{CFG.DYNALITE_PORT}")
-        return True
-    except Exception as e:
-        pass
-    return False
+def is_docker() -> bool:
+    path = "/proc/self/cgroup"
+    return (
+        os.path.exists("/.dockerenv")
+        or os.path.isfile(path)
+        and any("docker" in line for line in open(path))
+    )
 
 
 def create_app(config=None):
     # configure_logger()
     logger.info("creating flask app", config=config)
     region = "localhost"
-    host = f"http://localhost:{CFG.DYNALITE_PORT}"
-    if is_container():
-        host = f"http://dynalite:{CFG.DYNALITE_PORT}"
+    host = f"http://dynalite:{CFG.DYNALITE_PORT}" if is_docker() else CFG.DYNALITE_URL
     stripe.api_key = CFG.STRIPE_API_KEY
     if CFG.AWS_EXECUTION_ENV:
         region = "us-west-2"

--- a/src/hub/tests/conftest.py
+++ b/src/hub/tests/conftest.py
@@ -1,15 +1,18 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
+import json
 import os
 import sys
 import signal
 import subprocess
 import logging
 
+import backoff
+import docker
 import psutil
 import pytest
+import requests
 import stripe
 from flask import g
 
@@ -19,17 +22,18 @@ from shared.log import get_logger
 
 logger = get_logger()
 
-ddb_process = None
+IMAGE = "vitarn/dynalite:latest"
+CONTAINER_FOR_TESTING_LABEL = "pytest_docker_log"
+
+
+def _docker_client():
+    return docker.DockerClient("unix://var/run/docker.sock", version="auto")
 
 
 def pytest_configure():
     """Called before testing begins"""
-    global ddb_process
     for name in ("boto3", "botocore"):
         logging.getLogger(name).setLevel(logging.CRITICAL)
-    if os.getenv("AWS_LOCAL_DYNAMODB") is None:
-        os.environ["AWS_LOCAL_DYNAMODB"] = f"http://127.0.0.1:{CFG.DYNALITE_PORT}"
-
     # Latest boto3 now wants fake credentials around, so here we are.
     os.environ["AWS_ACCESS_KEY_ID"] = "fake"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "fake"
@@ -37,32 +41,57 @@ def pytest_configure():
     os.environ["ALLOWED_ORIGIN_SYSTEMS"] = "Test_system,Test_System,Test_System1"
     sys._called_from_test = True
 
-    # Locate absolute path of dynalite
-    dynalite = f"{CFG.REPO_ROOT}/node_modules/.bin/dynalite"
 
-    cmd = f"{dynalite} --port {CFG.DYNALITE_PORT}"
-    ddb_process = subprocess.Popen(
-        cmd, shell=True, env=os.environ, stdout=subprocess.PIPE
+def get_free_tcp_port():
+    import socket
+
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.bind(("", 0))
+    addr, port = tcp.getsockname()
+    logger.debug("port", port=port)
+    tcp.close()
+    return port
+
+
+def pull_image(image):
+    docker_client = docker.from_env()
+    response = docker_client.api.pull(image)
+    lines = [line for line in response.splitlines() if line]
+    pull_result = json.loads(lines[-1])
+    if "error" in pull_result:
+        raise Exception("Could not pull {}: {}".format(image, pull_result["error"]))
+
+
+@pytest.yield_fixture(scope="module", autouse=True)
+def dynamodb():
+    pull_image(IMAGE)
+    docker_client = docker.from_env()
+    host_port = get_free_tcp_port()
+    port_bindings = {4567: host_port}
+    host_config = docker_client.api.create_host_config(port_bindings=port_bindings)
+    container = docker_client.api.create_container(
+        image=IMAGE,
+        labels=[CONTAINER_FOR_TESTING_LABEL],
+        host_config=host_config,
+        ports=[4567],
     )
-    while 1:
-        line = ddb_process.stdout.readline()
-        if line.startswith(b"Listening"):
-            break
+    docker_client.api.start(container=container["Id"])
+    container_info = docker_client.api.inspect_container(container.get("Id"))
+    host_ip = container_info["NetworkSettings"]["Ports"]["4567/tcp"][0]["HostIp"]
+    host_port = container_info["NetworkSettings"]["Ports"]["4567/tcp"][0]["HostPort"]
+    yield f"http://{host_ip}:{host_port}"
+    docker_client.api.remove_container(container=container["Id"], force=True)
 
 
-def pytest_unconfigure():
-    del sys._called_from_test
-    global ddb_process
-    """Called after all tests run and warnings displayed"""
-    proc = psutil.Process(pid=ddb_process.pid)
-    child_procs = proc.children(recursive=True)
-    for p in [proc] + child_procs:
-        os.kill(p.pid, signal.SIGTERM)
-    ddb_process.wait()
+@backoff.on_exception(backoff.fibo, Exception, max_tries=8)
+def _check_container(url):
+    return requests.get(url)
 
 
 @pytest.fixture(autouse=True, scope="module")
-def app():
+def app(dynamodb):
+    os.environ["DYNALITE_URL"] = dynamodb
+    _check_container(dynamodb)
     app = create_app()
     with app.app.app_context():
         g.hub_table = app.app.hub_table

--- a/src/hub/tests/unit/stripe/event/test_stripe_events.py
+++ b/src/hub/tests/unit/stripe/event/test_stripe_events.py
@@ -14,8 +14,9 @@ from flask import Response
 from mockito import when, mock, unstub
 from datetime import datetime, timedelta
 
+from hub.tests import conftest
+
 from hub.shared.tests.unit.utils import run_view, run_event_process
-from hub.verifications.events_check import EventCheck, process_events
 from hub.shared.cfg import CFG
 from shared.log import get_logger
 
@@ -25,6 +26,8 @@ CWD = os.path.realpath(os.path.dirname(__file__))
 
 
 def test_hours_back():
+    from hub.verifications.events_check import EventCheck
+
     event_check_class = EventCheck(hours_back=1)
     assert isinstance(
         event_check_class.get_time_h_hours_ago(hours_back=event_check_class.hours_back),
@@ -32,14 +35,18 @@ def test_hours_back():
     )
 
 
-def test_process_missing_event():
+def test_process_missing_event(dynamodb):
+    from hub.verifications.events_check import EventCheck, process_events
+
     missing_event = "event.json"
     with open(os.path.join(CWD, missing_event)) as f:
         event_check = EventCheck(6)
         event_check.process_missing_event(json.load(f))
 
 
-def test_retrieve_events():
+def test_retrieve_events(dynamodb):
+    from hub.verifications.events_check import EventCheck, process_events
+
     missing_event = "event.json"
 
     def get_hours_back():
@@ -58,6 +65,8 @@ def test_retrieve_events():
 
 
 def test_retrieve_events_more():
+    from hub.verifications.events_check import EventCheck
+
     missing_event = "more_event.json"
 
     def get_hours_back():
@@ -78,8 +87,10 @@ def test_retrieve_events_more():
     unstub()
 
 
-def test_process_events():
+def test_process_events(dynamodb):
+    os.environ["DYNALITE_URL"] = dynamodb
     missing_event = "event.json"
+    from hub.verifications.events_check import process_events
 
     def get_hours_back():
         h_hours_ago = datetime.now() - timedelta(hours=6)

--- a/src/hub/verifications/events_check.py
+++ b/src/hub/verifications/events_check.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
+import sys
 import time
 from abc import ABC
 from datetime import datetime, timedelta
@@ -20,14 +20,17 @@ from shared.log import get_logger
 
 logger = get_logger()
 
-xray_recorder.configure(service="subhub-missing-events")
+if not hasattr(sys, "_called_from_test"):
+    xray_recorder.configure(service="subhub-missing-events")
 
-try:
+    try:
+        app = create_app()
+        XRayMiddleware(app.app, xray_recorder)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Exception occurred while loading app")
+        raise
+else:
     app = create_app()
-    XRayMiddleware(app.app, xray_recorder)
-except Exception:  # pylint: disable=broad-except
-    logger.exception("Exception occurred while loading app")
-    raise
 
 
 class EventCheck(ABC):

--- a/src/shared/cfg.py
+++ b/src/shared/cfg.py
@@ -292,18 +292,18 @@ class AutoConfigPlus(AutoConfig):  # pylint: disable=too-many-public-methods
         return self("LOCAL_FLASK_PORT", 5000, cast=int)
 
     @property
+    def DYNALITE_URL(self):
+        """
+        dynalite url
+        """
+        return self("DYNALITE_URL", "http://127.0.0.1:8000")
+
+    @property
     def DYNALITE_PORT(self):
         """
         dynalite port
         """
         return self("DYNALITE_PORT", 8000, cast=int)
-
-    @property
-    def DYNALITE_FILE(self):
-        """
-        dynalite output file
-        """
-        return self("DYNALITE_FILE", "dynalite.out")
 
     @property
     def SALESFORCE_BASKET_URI(self):

--- a/src/sub/app.py
+++ b/src/sub/app.py
@@ -89,9 +89,7 @@ def create_app(config=None) -> connexion.FlaskApp:
     # configure_logger()
     logger.info("creating flask app", config=config)
     region = "localhost"
-    host = f"http://localhost:{CFG.DYNALITE_PORT}"
-    if is_docker():
-        host = f"http://dynalite:{CFG.DYNALITE_PORT}"
+    host = f"http://dynalite:{CFG.DYNALITE_PORT}" if is_docker() else CFG.DYNALITE_URL
     stripe.api_key = CFG.STRIPE_API_KEY
     logger.info("aws", aws=CFG.AWS_EXECUTION_ENV)
     if CFG.AWS_EXECUTION_ENV:

--- a/src/sub/tests/unit/test_cfg.py
+++ b/src/sub/tests/unit/test_cfg.py
@@ -187,12 +187,9 @@ def test_DYNALITE_PORT():
         assert False
 
 
-def test_DYNALITE_FILE():
-    """
-    dynalite file
-    """
+def test_DYNALITE_URL():
     try:
-        CFG.DYNALITE_FILE
+        CFG.DYNALITE_URL
         assert True
     except:
         assert False

--- a/src/test_requirements.txt
+++ b/src/test_requirements.txt
@@ -13,3 +13,6 @@ jsoncompare==0.1.2
 pyparsing==2.4.0
 mypy==0.720
 responses==0.10.6
+docker==4.1.0
+backoff==1.8.0
+requests==2.22.0

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@ skipsdist=true
 
 [testenv]
 run_before =
-  ps -ef | grep -i dynalite | awk '{print $2}' | xargs kill -9 2&> /dev/null
-  ps -ef | grep -i kinesalite | awk '{print $2}' | xargs kill -9 2&> /dev/null
   export AWS_XRAY_SDK_ENABLED=false
 
 envdir = {toxinidir}/venv

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,23 +433,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.141.tgz#d81f4d0c562abe28713406b571ffb27692a82ae6"
   integrity sha512-v5NYIi9qEbFEUpCyikmnOYe4YlP8BMUdTcNCAquAKzu+FA7rZ1onj9x80mbnDdOW/K5bFf3Tv5kJplP33+gAbQ==
 
-abstract-leveldown@^6.1.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-6.2.1.tgz#37b655151e13c3d9b20fa3a04ce63ccaa345fce4"
-  integrity sha512-zUgomHedGBCThDkUtc1bfilu2jEhRZ7Dk3RePhtMma/akw7UK2Upm2R5Dd8ynRBEt3uscwbWO0VQNx22/7RtWg==
-  dependencies:
-    level-concat-iterator "~2.0.0"
-    level-supports "~1.0.0"
-    xtend "~4.0.0"
-
-abstract-leveldown@~6.1.0, abstract-leveldown@~6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-6.1.1.tgz#f44bad5862d71c7b418110d7698ac25bedf24396"
-  integrity sha512-7fK/KySVqzKIomdhkSWzX4YBQhzkzEMbWSiaB6mSN9e+ZdV3KEeKxia/8xQzCkATA5xnnukdP88cFR0D2FsFXw==
-  dependencies:
-    level-concat-iterator "~2.0.0"
-    xtend "~4.0.0"
-
 accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -630,7 +613,7 @@ async@^1.5.2, async@~1.5:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.0.0, async@^2.6.3:
+async@^2.0.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -684,11 +667,6 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
-
-big.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 bignumber.js@^8.0.1:
   version "8.1.1"
@@ -791,7 +769,7 @@ buffer-alloc@^1.2.0:
     buffer-alloc-unsafe "^1.1.0"
     buffer-fill "^1.0.0"
 
-buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
+buffer-crc32@^0.2.1, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
@@ -1310,14 +1288,6 @@ defer-to-connect@^1.0.1:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.0.2.tgz#4bae758a314b034ae33902b5aac25a8dd6a8633e"
   integrity sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==
 
-deferred-leveldown@~5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-5.2.1.tgz#8da87909cd3269c2d6aff67b1e607f93e4d96c15"
-  integrity sha512-PwXZRn5EmW+IKYVAYVc7G9FsRkShr0myPubPuq+mtLhDq9xSUqfvTlNZKoeQGeXACHXkeCFurKrz5oo6TZ3qwg==
-  dependencies:
-    abstract-leveldown "~6.1.0"
-    inherits "^2.0.3"
-
 deferred@^0.7.11:
   version "0.7.11"
   resolved "https://registry.yarnpkg.com/deferred/-/deferred-0.7.11.tgz#8c3f272fd5e6ce48a969cb428c0d233ba2146322"
@@ -1357,11 +1327,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-defined@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-0.0.0.tgz#f35eea7d705e933baf13b2f03b3f83d921403b3e"
-  integrity sha1-817qfXBekzuvE7LwOz+D2SFAOz4=
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1418,24 +1383,6 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-dynalite@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/dynalite/-/dynalite-3.0.0.tgz#c3a4c24885aa31e729ca5659f9cbbedfd28e8978"
-  integrity sha512-1T5h4N4E5iGIiIwlEBU8iHuIDbWxbIWkvmsBJqu8ScIYgV5IRVdgFlVtD3lF20o7bhnAIspeGvjNO4y5cigEQw==
-  dependencies:
-    async "^2.6.3"
-    big.js "^5.2.2"
-    buffer-crc32 "^0.2.13"
-    lazy "^1.0.11"
-    levelup "^4.2.0"
-    lock "^1.1.0"
-    memdown "^5.0.0"
-    minimist "^1.2.0"
-    once "^1.4.0"
-    subleveldown "^4.1.3"
-  optionalDependencies:
-    leveldown "^5.2.1"
-
 dynamodb-localhost@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/dynamodb-localhost/-/dynamodb-localhost-0.0.7.tgz#6642d6eb7a29a8c586cc783dd6a59ec3dc00e2ad"
@@ -1468,16 +1415,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding-down@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/encoding-down/-/encoding-down-6.2.0.tgz#7ca52446dac6e0fd09ad3584a7359809ea1a4844"
-  integrity sha512-XlIoQMBMbU4aE01uSKpAix0sXBJWK8YPhuOdvKa1CroThZyUpj0zWzt+bbe7g1KWsdhNFFzHkQHSdDymVtpJ1w==
-  dependencies:
-    abstract-leveldown "^6.1.1"
-    inherits "^2.0.3"
-    level-codec "^9.0.0"
-    level-errors "^2.0.0"
-
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -1501,13 +1438,6 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
-
-errno@~0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
-  integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
-  dependencies:
-    prr "~1.0.1"
 
 es-abstract@^1.11.0:
   version "1.15.0"
@@ -1962,11 +1892,6 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-functional-red-black-tree@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
 gauge@~1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-1.2.7.tgz#e9cec5483d3d4ee0ef44b60a7d99e4935e136d93"
@@ -2275,11 +2200,6 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immediate@~3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
-  integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
-
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -2298,7 +2218,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2828,11 +2748,6 @@ latest-version@^5.0.0:
   dependencies:
     package-json "^6.3.0"
 
-lazy@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/lazy/-/lazy-1.0.11.tgz#daa068206282542c088288e975c297c1ae77b690"
-  integrity sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=
-
 lazystream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
@@ -2840,77 +2755,12 @@ lazystream@^1.0.0:
   dependencies:
     readable-stream "^2.0.5"
 
-level-codec@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-9.0.1.tgz#042f4aa85e56d4328ace368c950811ba802b7247"
-  integrity sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==
-
-level-concat-iterator@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz#1d1009cf108340252cb38c51f9727311193e6263"
-  integrity sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==
-
-level-errors@^2.0.0, level-errors@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/level-errors/-/level-errors-2.0.1.tgz#2132a677bf4e679ce029f517c2f17432800c05c8"
-  integrity sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==
-  dependencies:
-    errno "~0.1.1"
-
-level-iterator-stream@~4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz#65c467070c0788fe0d08a0c1ed600c3b9e82bc8d"
-  integrity sha512-pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^3.0.2"
-    xtend "^4.0.0"
-
-level-option-wrap@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/level-option-wrap/-/level-option-wrap-1.1.0.tgz#ad20e68d9f3c22c8897531cc6aa7af596b1ed129"
-  integrity sha1-rSDmjZ88IsiJdTHMaqevWWse0Sk=
-  dependencies:
-    defined "~0.0.0"
-
-level-supports@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-1.0.0.tgz#376f3f2339c23be0ba2fe62b0fa0e3ac7d6d9988"
-  integrity sha512-01PKZumFhgysuHUbRz4c9DyA1egmcHJBAsZbm0Vf5agojC3uWOvAnhOD4swNUgHlfJBymXLi/xkBaEckeNRSvA==
-  dependencies:
-    xtend "^4.0.2"
-
-leveldown@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-5.2.1.tgz#eadc2184ab4c83fe0d74853384fe99dc0a0de6be"
-  integrity sha512-369I1rGibXV7CIoLhsSpp/ExwQucI3xUe0RXQrMu4ji6OG9PFMVAQuzsEXKwAi3BWsjFzcFtodAP8MW5fmfung==
-  dependencies:
-    abstract-leveldown "~6.1.1"
-    napi-macros "~2.0.0"
-    node-gyp-build "~4.1.0"
-
-levelup@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/levelup/-/levelup-4.3.0.tgz#b6934483787e7558a340d54b4364ea3361150b73"
-  integrity sha512-6sC7hXr43Q3vDq/nB4UC4mU6sVxhFJZXYSfKJd5iDHgqQzJx6RIxRiFbXakQiNvdVRz6RO/HNmQqr1W06dne2w==
-  dependencies:
-    deferred-leveldown "~5.2.1"
-    level-errors "~2.0.0"
-    level-iterator-stream "~4.0.0"
-    level-supports "~1.0.0"
-    xtend "~4.0.0"
-
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
   integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   dependencies:
     immediate "~3.0.5"
-
-lock@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/lock/-/lock-1.1.0.tgz#53157499d1653b136ca66451071fca615703fa55"
-  integrity sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU=
 
 lodash.difference@^4.5.0:
   version "4.5.0"
@@ -3027,11 +2877,6 @@ lsmod@1.0.0:
   resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
   integrity sha1-mgD3bco26yP6BTUK/htYXUKZ5ks=
 
-ltgt@~2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
-  integrity sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=
-
 luxon@^1.17.1:
   version "1.19.3"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.19.3.tgz#86c04a1395529b4386ae235a8fe16d0a82a0695b"
@@ -3060,18 +2905,6 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
-memdown@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/memdown/-/memdown-5.0.0.tgz#ac4cf88401c14eda1a4e26e1b1d004cb733c6e1e"
-  integrity sha512-xbt+LqodsJqoUtNg1JOuNpA806Yo8tjsFATRoZVIlGPpVslmPd5/6ET+s7xOWse/iNnSCRTwKN/9LegeDewzQw==
-  dependencies:
-    abstract-leveldown "~6.1.0"
-    functional-red-black-tree "~1.0.1"
-    immediate "~3.2.3"
-    inherits "~2.0.1"
-    ltgt "~2.2.0"
-    safe-buffer "~5.2.0"
 
 memoizee@^0.4.14:
   version "0.4.14"
@@ -3228,11 +3061,6 @@ nanomatch@^1.2.13:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-napi-macros@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-2.0.0.tgz#2b6bae421e7b96eb687aa6c77a7858640670001b"
-  integrity sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==
-
 native-promise-only@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
@@ -3280,11 +3108,6 @@ node-fetch@^2.3.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
-node-gyp-build@~4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.1.1.tgz#d7270b5d86717068d114cc57fff352f96d745feb"
-  integrity sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==
 
 node.extend@1.0.8:
   version "1.0.8"
@@ -3626,11 +3449,6 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
 
-prr@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
-  integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
-
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -3715,11 +3533,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-reachdown@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/reachdown/-/reachdown-1.0.0.tgz#c63715190c9a0dd108bea3610bf9690ad0983edb"
-  integrity sha512-Ty7X/t52GwgRam3SMpZC2grmutuUarkiD4sVhjM8g8/5NlX8PAEsYO/pyx6nTTqS9udee1j1BxaAS/f6Rm8SMw==
-
 readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -3732,15 +3545,6 @@ readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.0.6, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readable-stream@^3.0.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
-  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readdirp@~3.1.3:
   version "3.1.3"
@@ -3880,7 +3684,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -4308,13 +4112,6 @@ string.prototype.trimright@^2.1.0:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -4366,18 +4163,6 @@ strip-outer@^1.0.0:
   integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
   dependencies:
     escape-string-regexp "^1.0.2"
-
-subleveldown@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/subleveldown/-/subleveldown-4.1.3.tgz#1083a05e0ef106bf5899496dd9ef6c6a6e3b1046"
-  integrity sha512-u2zjsWUvqfO+pZo/81d4WlFzxnB+lS+YprSLRCBU7/3ujh7d85poPHOtEjJXPQFQsMMeYMbJ7qsdNU/SBKGDig==
-  dependencies:
-    abstract-leveldown "^6.1.1"
-    encoding-down "^6.2.0"
-    inherits "^2.0.3"
-    level-option-wrap "^1.1.0"
-    levelup "^4.2.0"
-    reachdown "^1.0.0"
 
 superagent@^3.8.3:
   version "3.8.3"
@@ -4719,7 +4504,7 @@ utf8@3.0.0:
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
   integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -4830,7 +4615,7 @@ xmlbuilder@~9.0.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
-xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.0:
+xtend@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
This pull request (PR) removes an outstanding issue that the subhub code has had for some time.  The issue is that there is an issue in which under certain circumstances that there is contention for the port used by the instantiated instance of Dynalite for the purposes of execution of unit tests against.  Additionally, a further but known defect is that the build system, doit and the test framework both attempt to managed the life cycle of the dynalite.

This PR is a free-time contribution and I would like to call out the following:

1. A black formatter, pre-commit hook was added as a few times, I did commit code that broke the build on the formatter check.  This pre-commit step ensure the black formatter is ran prior to code commit so in that sense, it is a superset of doit's ability to do this.  We should discuss removing this extraneous step from doit in the future to lower it's overall complexity given this.

2.  There exists duplicated code in 2 test fixtures to spin up dynalite for the sub and hub.  We may be able to abstract this into shared code but caveat emptor as this will potentially reduce the ability to call `tox --parallel auto` should we want to do this.  This is due to the abilities of both sub and hub to spin up dependent test fixtures on differing ports.  There is some additional work required to abstract this into a shared pytest fixture that is parallelizable.

3.  Changes the docker-compose.yml to leverage prebuilt docker images from dockerhub versus building from source.  This speeds up local development environment, build times.

4.  Caching the dynalite docker image in TravisCI needs to be investigated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/300)
<!-- Reviewable:end -->
