### PR TITLE
Unpin Python3 APK package version

### DIFF
--- a/etc/alpine-packages
+++ b/etc/alpine-packages
@@ -1,7 +1,7 @@
 build-base==0.5-r1
 libgit2-dev==0.28.2-r0
 libc-dev==0.7.1-r0
-python3-dev==3.7.3-r0
+python3-dev
 libffi-dev==3.2.1-r6
 zeromq-dev==4.3.2-r1
 linux-headers==4.19.36-r0


### PR DESCRIPTION
New lessons learned on Alpine.  At some point, Alpine Package Managed decided to always move forward on package versions and drop older versions on each release if that new version was available and stable.  I missed the memo but [here](https://medium.com/@stschindler/the-problem-with-docker-and-alpines-package-pinning-18346593e891) is the TLDR.  This pull request relaxes the issue alone that @marty331 found but we should follow up and rectify the rest of the packages with this knowledge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/303)
<!-- Reviewable:end -->
