### PR TITLE
Stack protection of the production environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,23 @@
 {
-  "description": "automation tools for running locally and deploying to aws",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mozilla/subhub"
-  },
-  "license": "MPL-2.0",
-  "devDependencies": {
-    "@hapi/hoek": "8.2.4",
-    "dynalite": "3.0.0",
-    "serverless": "1.53.0",
-    "serverless-domain-manager": "3.3.0",
-    "serverless-dynamodb-local": "0.2.38",
-    "serverless-offline": "5.11.0",
-    "serverless-package-external": "1.1.1",
-    "serverless-plugin-aws-alerts": "1.4.0",
-    "serverless-plugin-canary-deployments": "0.4.8",
-    "serverless-plugin-tracing": "2.0.0",
-    "serverless-python-requirements": "5.0.0",
-    "serverless-wsgi": "1.7.3"
-  }
+    "description": "automation tools for running locally and deploying to aws",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mozilla/subhub"
+    },
+    "license": "MPL-2.0",
+    "devDependencies": {
+        "@hapi/hoek": "8.2.4",
+        "dynalite": "3.0.0",
+        "serverless": "1.53.0",
+        "serverless-domain-manager": "3.3.0",
+        "serverless-dynamodb-local": "0.2.38",
+        "serverless-offline": "5.11.0",
+        "serverless-package-external": "1.1.1",
+        "serverless-plugin-aws-alerts": "1.4.0",
+        "serverless-plugin-canary-deployments": "0.4.8",
+        "serverless-plugin-tracing": "2.0.0",
+        "serverless-python-requirements": "5.0.0",
+        "serverless-wsgi": "1.7.3",
+        "serverless-stack-termination-protection": "1.0.0"
+    }
 }

--- a/services/fxa/serverless.yml
+++ b/services/fxa/serverless.yml
@@ -12,9 +12,12 @@ package:
 
 custom:
   stage: ${opt:stage, self:provider.stage}
+
+  # AWS DynamoDB Table definitions used by resources/dynamodb-table.yml
   usersTable: ${env:USER_TABLE}
   deletedUsersTable: ${env:DELETED_USER_TABLE}
   eventsTable: ${env:EVENT_TABLE}
+
   prefix: ${self:provider.stage}-${self:service.name}
   subdomain: ${self:provider.stage}.${self:service.name}
   pythonRequirements:
@@ -40,6 +43,9 @@ custom:
       migrate: true
       seed: true
       convertEmptyValues: true
+  serverlessTerminationProtection:
+    stages:
+      - prod
   customDomain:
     domainName: ${self:custom.subdomain}.mozilla-subhub.app
     certificateName: ${self:custom.subdomain}.mozilla-subhub.app
@@ -116,7 +122,10 @@ plugins:
   - serverless-dynamodb-local
   - serverless-package-external
   - serverless-plugin-canary-deployments
+  - serverless-stack-termination-protection
+  # NOTE: serverless-offline needs to be the last plugin loaded.
   - serverless-offline
+
 provider:
   name: aws
   runtime: python3.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,6 +4052,11 @@ serverless-python-requirements@5.0.0:
     sha256-file "1.0.0"
     shell-quote "^1.6.1"
 
+serverless-stack-termination-protection@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.0.tgz#88ba52747ff2b8e17736a8f4b34d2d51ad270229"
+  integrity sha512-0IZVACQmYeEwmKVpDMtYVHeaXujbOhs0hLuR8G/J/b4k8mFIFAMjXjm3Ye1De0kfR8b+UDtL+JHFI2siP7zA9g==
+
 serverless-wsgi@1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/serverless-wsgi/-/serverless-wsgi-1.7.3.tgz#34c7989718a3cb52a9148bdba8d7d6c2da0f0328"


### PR DESCRIPTION
This pull request (PR) adds a layer of protection to the production environment deployments.  For this, in production, the stack termination is set to enabled as shown by the below screenshot.  This will prevent a devops user in the AWS Console from accidentally deleting the production environment.  This is important as we commonly do this for both the dev and fab environments.  If we accidentally click on prod during this process, this will prevent accidental deletion.

![Screen Shot 2019-10-16 at 1 47 42 PM](https://user-images.githubusercontent.com/3189997/66949338-f3686880-f01b-11e9-8f56-bc886f18c186.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/318)
<!-- Reviewable:end -->
