### PR TITLE
reordred, fixed blocks of imports

### DIFF
--- a/services/fxa/hubhandler.py
+++ b/services/fxa/hubhandler.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-
 import newrelic.agent
 import serverless_wsgi
 
+from os.path import join, dirname, realpath
+
 serverless_wsgi.TEXT_MIME_TYPES.append("application/custom+json")
 
-from os.path import join, dirname, realpath
 # First some funky path manipulation so that we can work properly in
 # the AWS environment
 sys.path.insert(0, join(dirname(realpath(__file__)), 'src'))

--- a/services/fxa/miahandler.py
+++ b/services/fxa/miahandler.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-
 import newrelic.agent
 import serverless_wsgi
 import structlog
 
 from os.path import join, dirname, realpath
+
 # First some funky path manipulation so that we can work properly in
 # the AWS environment
 sys.path.insert(0, join(dirname(realpath(__file__)), 'src'))

--- a/services/fxa/subhandler.py
+++ b/services/fxa/subhandler.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-
 import newrelic.agent
 import serverless_wsgi
 
+from os.path import join, dirname, realpath
+
 serverless_wsgi.TEXT_MIME_TYPES.append("application/custom+json")
 
-from os.path import join, dirname, realpath
 # First some funky path manipulation so that we can work properly in
 # the AWS environment
 sys.path.insert(0, join(dirname(realpath(__file__)), 'src'))

--- a/src/hub/app.py
+++ b/src/hub/app.py
@@ -4,7 +4,6 @@
 
 import os
 import sys
-
 import connexion
 import stripe
 

--- a/src/hub/routes/abstract.py
+++ b/src/hub/routes/abstract.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from abc import ABC
-
 import flask
+
+from abc import ABC
 
 from shared.log import get_logger
 

--- a/src/hub/routes/firefox.py
+++ b/src/hub/routes/firefox.py
@@ -6,7 +6,6 @@ import boto3
 import json
 
 from typing import Dict
-
 from botocore.exceptions import ClientError
 from stripe.error import APIConnectionError
 

--- a/src/hub/tests/conftest.py
+++ b/src/hub/tests/conftest.py
@@ -7,7 +7,6 @@ import sys
 import signal
 import subprocess
 import logging
-
 import psutil
 import pytest
 import stripe

--- a/src/hub/tests/unit/stripe/charge/test_stripe_charge.py
+++ b/src/hub/tests/unit/stripe/charge/test_stripe_charge.py
@@ -7,8 +7,8 @@ import mockito
 import requests
 import boto3
 import flask
-from hub.shared.cfg import CFG
 
+from hub.shared.cfg import CFG
 from hub.shared.tests.unit.utils import run_test, MockSqsClient
 
 CWD = os.path.realpath(os.path.dirname(__file__))

--- a/src/hub/tests/unit/stripe/customer/test_stripe_customer.py
+++ b/src/hub/tests/unit/stripe/customer/test_stripe_customer.py
@@ -20,7 +20,6 @@ from hub.shared.tests.unit.utils import run_test, MockSqsClient, MockSnsClient
 from hub.shared.cfg import CFG
 from shared.log import get_logger
 
-
 logger = get_logger()
 
 CWD = os.path.realpath(os.path.dirname(__file__))

--- a/src/hub/tests/unit/stripe/invoice/test_stripe_invoice.py
+++ b/src/hub/tests/unit/stripe/invoice/test_stripe_invoice.py
@@ -12,7 +12,6 @@ import flask
 
 from hub.shared.cfg import CFG
 from hub.shared import secrets
-
 from hub.shared.tests.unit.utils import run_test, MockSqsClient
 
 CWD = os.path.realpath(os.path.dirname(__file__))

--- a/src/hub/tests/unit/stripe/payment/test_stripe_payments.py
+++ b/src/hub/tests/unit/stripe/payment/test_stripe_payments.py
@@ -13,7 +13,6 @@ from mockito import when, mock, unstub
 
 from hub.shared.cfg import CFG
 from hub.shared import secrets
-
 from hub.shared.tests.unit.utils import run_test, MockSqsClient
 
 CWD = os.path.realpath(os.path.dirname(__file__))

--- a/src/hub/verifications/events_check.py
+++ b/src/hub/verifications/events_check.py
@@ -3,12 +3,11 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import time
+import stripe
+
 from abc import ABC
 from datetime import datetime, timedelta
 from typing import Dict, Any
-
-import stripe
-
 from flask import current_app
 from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware

--- a/src/shared/cfg.py
+++ b/src/shared/cfg.py
@@ -16,7 +16,6 @@ from datetime import datetime
 from decouple import UndefinedValueError, AutoConfig, config
 from functools import lru_cache
 from subprocess import Popen, CalledProcessError, PIPE
-
 from structlog import get_logger  # because circular dep otherwise
 
 logger = get_logger()

--- a/src/shared/db.py
+++ b/src/shared/db.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from typing import Optional, Any, List, Dict
-
 from pynamodb.attributes import UnicodeAttribute, ListAttribute
 from pynamodb.connection import Connection
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection

--- a/src/shared/log.py
+++ b/src/shared/log.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import logging.config
+
 from shared.cfg import CFG
 
 LOGGER = None

--- a/src/shared/vendor.py
+++ b/src/shared/vendor.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from typing import List, Optional, Dict, Any
-
+from tenacity import retry, wait_exponential, stop_after_attempt
 from stripe import Customer, Subscription, Charge, Invoice, Plan, Product, api_key
 from stripe.error import (
     InvalidRequestError,
@@ -15,7 +15,6 @@ from stripe.error import (
     StripeErrorWithParamCode,
     AuthenticationError,
 )
-from tenacity import retry, wait_exponential, stop_after_attempt
 
 from shared.log import get_logger
 

--- a/src/sub/app.py
+++ b/src/sub/app.py
@@ -4,14 +4,12 @@
 
 import os
 import sys
-import inspect
-
-from typing import Optional, Union
-
 import logging
 import connexion
 import stripe
 import stripe.error
+
+from typing import Optional, Union
 from flask import current_app, g, jsonify
 from flask_cors import CORS
 from flask import request

--- a/src/sub/messages.py
+++ b/src/sub/messages.py
@@ -8,11 +8,8 @@ import boto3
 from abc import ABC
 from botocore.exceptions import ClientError
 
-from botocore.exceptions import ClientError
-
 from sub.shared.cfg import CFG
 from shared.log import get_logger
-
 
 logger = get_logger()
 

--- a/src/sub/tests/conftest.py
+++ b/src/sub/tests/conftest.py
@@ -9,20 +9,17 @@ import subprocess
 import uuid
 import logging
 import json
-
-from unittest.mock import Mock, MagicMock, PropertyMock
-
 import psutil
 import pytest
 import stripe
 
 from flask import g
+from unittest.mock import Mock, MagicMock, PropertyMock
 
 from sub import payments
 from sub.app import create_app
 from sub.shared.cfg import CFG
 from sub.customer import create_customer
-
 from shared.log import get_logger
 
 logger = get_logger()

--- a/src/sub/tests/unit/test_subhub.py
+++ b/src/sub/tests/unit/test_subhub.py
@@ -3,16 +3,15 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import json
-from unittest.mock import Mock, MagicMock
 import mock
-
 import connexion
 import stripe.error
+
 from stripe.util import convert_to_stripe_object
+from unittest.mock import Mock, MagicMock
 
 from sub.app import create_app
 from sub.shared.tests.unit.utils import MockSubhubUser
-
 from shared.log import get_logger
 
 logger = get_logger()


### PR DESCRIPTION
```
 sidler@76  ~/repos/mozilla/subhub   fixup-import-blocks  doit curl
.  curl
curl --silent https://dev.fxa.mozilla-subhub.app/v1/sub/version
{
  "BRANCH": "fixup-import-blocks",
  "REVISION": "b9fd75b4d99d959ce18773b134497dabb1c0627f",
  "VERSION": "v0.0.4-70-gb9fd75b"
}
curl --silent https://dev.fxa.mozilla-subhub.app/v1/sub/deployed
{
  "DEPLOYED_BY": "sidler@76",
  "DEPLOYED_ENV": "dev",
  "DEPLOYED_WHEN": "2019-10-23T18:18:44.901786"
}
curl --silent https://dev.fxa.mozilla-subhub.app/v1/hub/version
{
  "BRANCH": "fixup-import-blocks",
  "REVISION": "b9fd75b4d99d959ce18773b134497dabb1c0627f",
  "VERSION": "v0.0.4-70-gb9fd75b"
}
curl --silent https://dev.fxa.mozilla-subhub.app/v1/hub/deployed
{
  "DEPLOYED_BY": "sidler@76",
  "DEPLOYED_ENV": "dev",
  "DEPLOYED_WHEN": "2019-10-23T18:18:44.901786"
}

```