### PR TITLE
bug hub/vendor/invoices.py: filtered initial payment failures

### DIFF
--- a/src/hub/tests/unit/fixtures/stripe_in_payment_failed_event.json
+++ b/src/hub/tests/unit/fixtures/stripe_in_payment_failed_event.json
@@ -1,0 +1,135 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "invoice.payment_failed",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2018-02-06",
+  "data": {
+    "object": {
+      "id": "in_000000",
+      "object": "invoice",
+      "account_country": "US",
+      "account_name": "Mozilla Corporation",
+      "amount_due": 100,
+      "amount_paid": 0,
+      "amount_remaining": 100,
+      "application_fee_amount": null,
+      "attempt_count": 2,
+      "attempted": true,
+      "auto_advance": false,
+      "billing": "charge_automatically",
+      "billing_reason": "subscription_cycle",
+      "charge": "ch_000000",
+      "collection_method": "charge_automatically",
+      "created": 1558624628,
+      "currency": "usd",
+      "custom_fields": null,
+      "customer": "cus_00000000000",
+      "customer_address": null,
+      "customer_email": "tuesday521a@gmail.com",
+      "customer_name": null,
+      "customer_phone": null,
+      "customer_shipping": null,
+      "customer_tax_exempt": "none",
+      "customer_tax_ids": [
+      ],
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [
+      ],
+      "description": null,
+      "discount": null,
+      "due_date": null,
+      "ending_balance": 0,
+      "footer": null,
+      "hosted_invoice_url": "https://pay.stripe.com/invoice/invst_97MoTQlghQYM3p2W7iCVIoSD7J",
+      "invoice_pdf": "https://pay.stripe.com/invoice/invst_97MoTQlghQYM3p2W7iCVIoSD7J/pdf",
+      "lines": {
+        "object": "list",
+        "data": [
+          {
+            "id": "sli_6182144c6286e4",
+            "object": "line_item",
+            "amount": 100,
+            "currency": "usd",
+            "description": "1 Moz-Sub × Moz_Sub (at $1.00 / day)",
+            "discountable": true,
+            "livemode": false,
+            "metadata": {
+            },
+            "period": {
+              "end": 1558711028,
+              "start": 1558624628
+            },
+            "plan": {
+              "id": "plan_000000",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 100,
+              "billing_scheme": "per_unit",
+              "created": 1557867224,
+              "currency": "usd",
+              "interval": "day",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+              },
+              "nickname": "Daily Subscription",
+              "product": "prod_000000",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "proration": false,
+            "quantity": 1,
+            "subscription": "sub_000000",
+            "subscription_item": "si_00000",
+            "tax_amounts": [
+            ],
+            "tax_rates": [
+            ],
+            "type": "subscription"
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/invoices/in_000000/lines"
+      },
+      "livemode": false,
+      "metadata": {
+      },
+      "next_payment_attempt": null,
+      "number": "3D000-0003",
+      "paid": false,
+      "payment_intent": "pi_000000",
+      "period_end": 1558624628,
+      "period_start": 1558538228,
+      "post_payment_credit_notes_amount": 0,
+      "pre_payment_credit_notes_amount": 0,
+      "receipt_number": null,
+      "starting_balance": 0,
+      "statement_descriptor": null,
+      "status": "open",
+      "status_transitions": {
+        "finalized_at": 1558639040,
+        "marked_uncollectible_at": null,
+        "paid_at": null,
+        "voided_at": null
+      },
+      "subscription": "sub_000000",
+      "subtotal": 100,
+      "tax": null,
+      "tax_percent": null,
+      "total": 100,
+      "total_tax_amounts": [
+      ],
+      "webhooks_delivered_at": 1558635387
+    }
+  }
+}

--- a/src/hub/tests/unit/fixtures/stripe_in_payment_failed_event_sub_create.json
+++ b/src/hub/tests/unit/fixtures/stripe_in_payment_failed_event_sub_create.json
@@ -1,0 +1,135 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "invoice.payment_failed",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2018-02-06",
+  "data": {
+    "object": {
+      "id": "in_000000",
+      "object": "invoice",
+      "account_country": "US",
+      "account_name": "Mozilla Corporation",
+      "amount_due": 100,
+      "amount_paid": 0,
+      "amount_remaining": 100,
+      "application_fee_amount": null,
+      "attempt_count": 2,
+      "attempted": true,
+      "auto_advance": false,
+      "billing": "charge_automatically",
+      "billing_reason": "subscription_create",
+      "charge": "ch_000000",
+      "collection_method": "charge_automatically",
+      "created": 1558624628,
+      "currency": "usd",
+      "custom_fields": null,
+      "customer": "cus_00000000000",
+      "customer_address": null,
+      "customer_email": "tuesday521a@gmail.com",
+      "customer_name": null,
+      "customer_phone": null,
+      "customer_shipping": null,
+      "customer_tax_exempt": "none",
+      "customer_tax_ids": [
+      ],
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [
+      ],
+      "description": null,
+      "discount": null,
+      "due_date": null,
+      "ending_balance": 0,
+      "footer": null,
+      "hosted_invoice_url": "https://pay.stripe.com/invoice/invst_97MoTQlghQYM3p2W7iCVIoSD7J",
+      "invoice_pdf": "https://pay.stripe.com/invoice/invst_97MoTQlghQYM3p2W7iCVIoSD7J/pdf",
+      "lines": {
+        "object": "list",
+        "data": [
+          {
+            "id": "sli_6182144c6286e4",
+            "object": "line_item",
+            "amount": 100,
+            "currency": "usd",
+            "description": "1 Moz-Sub × Moz_Sub (at $1.00 / day)",
+            "discountable": true,
+            "livemode": false,
+            "metadata": {
+            },
+            "period": {
+              "end": 1558711028,
+              "start": 1558624628
+            },
+            "plan": {
+              "id": "plan_000000",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 100,
+              "billing_scheme": "per_unit",
+              "created": 1557867224,
+              "currency": "usd",
+              "interval": "day",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+              },
+              "nickname": "Daily Subscription",
+              "product": "prod_000000",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "proration": false,
+            "quantity": 1,
+            "subscription": "sub_000000",
+            "subscription_item": "si_00000",
+            "tax_amounts": [
+            ],
+            "tax_rates": [
+            ],
+            "type": "subscription"
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/invoices/in_000000/lines"
+      },
+      "livemode": false,
+      "metadata": {
+      },
+      "next_payment_attempt": null,
+      "number": "3D000-0003",
+      "paid": false,
+      "payment_intent": "pi_000000",
+      "period_end": 1558624628,
+      "period_start": 1558538228,
+      "post_payment_credit_notes_amount": 0,
+      "pre_payment_credit_notes_amount": 0,
+      "receipt_number": null,
+      "starting_balance": 0,
+      "statement_descriptor": null,
+      "status": "open",
+      "status_transitions": {
+        "finalized_at": 1558639040,
+        "marked_uncollectible_at": null,
+        "paid_at": null,
+        "voided_at": null
+      },
+      "subscription": "sub_000000",
+      "subtotal": 100,
+      "tax": null,
+      "tax_percent": null,
+      "total": 100,
+      "total_tax_amounts": [
+      ],
+      "webhooks_delivered_at": 1558635387
+    }
+  }
+}

--- a/src/hub/tests/unit/stripe/invoice/test_stripe_invoice.py
+++ b/src/hub/tests/unit/stripe/invoice/test_stripe_invoice.py
@@ -2,52 +2,91 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import os
 import mock
+import unittest
 import json
-import mockito
-import requests
-import boto3
-import flask
 
-from hub.shared.cfg import CFG
-from hub.shared import secrets
-from hub.shared.tests.unit.utils import run_test, MockSqsClient
+from stripe.util import convert_to_stripe_object
+from stripe.error import InvalidRequestError
 
-CWD = os.path.realpath(os.path.dirname(__file__))
+from hub.vendor.invoices import StripeInvoicePaymentFailed
 
 
-def run_customer(mocker, data, filename):
-    # using pytest mock
-    mocker.patch.object(flask, "g")
-    flask.g.return_value = ""
+class StripeInvoicePaymentFailedTest(unittest.TestCase):
+    def setUp(self) -> None:
+        with open("tests/unit/fixtures/stripe_prod_test1.json") as fh:
+            prod_test1 = json.loads(fh.read())
+        self.product = convert_to_stripe_object(prod_test1)
 
-    run_test(filename, cwd=CWD)
+        with open("tests/unit/fixtures/stripe_in_payment_failed_event.json") as fh:
+            self.payment_failed_event = json.loads(fh.read())
 
+        with open(
+            "tests/unit/fixtures/stripe_in_payment_failed_event_sub_create.json"
+        ) as fh:
+            self.payment_failed_event_sub_create = json.loads(fh.read())
 
-@mock.patch("stripe.Product.retrieve")
-def test_stripe_invoice_payment_failed(mock_product, mocker):
-    fh = open("tests/unit/fixtures/stripe_prod_test1.json")
-    prod_test1 = json.loads(fh.read())
-    fh.close()
-    mock_product.return_value = prod_test1
+        product_patcher = mock.patch("stripe.Product.retrieve")
+        run_pipeline_patcher = mock.patch("hub.routes.pipeline.RoutesPipeline.run")
 
-    data = {
-        "event_id": "evt_00000000000000",
-        "event_type": "invoice.payment_failed",
-        "customer_id": "cus_00000000000",
-        "subscription_id": "sub_000000",
-        "currency": "usd",
-        "charge_id": "ch_000000",
-        "amount_due": 100,
-        "created": 1558624628,
-        "nickname": "Project Guardian (Daily)",
-    }
-    basket_url = CFG.SALESFORCE_BASKET_URI + CFG.BASKET_API_KEY
-    response = mockito.mock({"status_code": 200, "text": "Ok"}, spec=requests.Response)
-    mockito.when(boto3).client("sqs", region_name=CFG.AWS_REGION).thenReturn(
-        MockSqsClient
-    )
-    mockito.when(requests).post(basket_url, json=data).thenReturn(response)
-    filename = "invoice-payment-failed.json"
-    run_customer(mocker, data, filename)
+        self.addCleanup(product_patcher.stop)
+        self.addCleanup(run_pipeline_patcher.stop)
+
+        self.mock_product = product_patcher.start()
+        self.mock_run_pipeline = run_pipeline_patcher.start()
+
+    def test_run_success(self):
+        self.mock_product.return_value = self.product
+        self.mock_run_pipeline.return_value = None
+
+        did_run = StripeInvoicePaymentFailed(self.payment_failed_event).run()
+
+        assert did_run
+
+    def test_run_subscription_create(self):
+        self.mock_product.return_value = self.product
+        self.mock_run_pipeline.return_value = None
+
+        did_run = StripeInvoicePaymentFailed(self.payment_failed_event_sub_create).run()
+
+        assert did_run == False
+
+    def test_create_payload(self):
+        self.mock_product.return_value = self.product
+
+        expected_payload = {
+            "event_id": "evt_00000000000000",
+            "event_type": "invoice.payment_failed",
+            "customer_id": "cus_00000000000",
+            "subscription_id": "sub_000000",
+            "currency": "usd",
+            "charge_id": "ch_000000",
+            "amount_due": 100,
+            "created": 1558624628,
+            "nickname": "Project Guardian (Daily)",
+        }
+        actual_payload = StripeInvoicePaymentFailed(
+            self.payment_failed_event
+        ).create_payload()
+
+        assert expected_payload == actual_payload
+
+    def test_create_payload_nickname_error(self):
+        self.mock_product.side_effect = InvalidRequestError(message="", param="")
+
+        expected_payload = {
+            "event_id": "evt_00000000000000",
+            "event_type": "invoice.payment_failed",
+            "customer_id": "cus_00000000000",
+            "subscription_id": "sub_000000",
+            "currency": "usd",
+            "charge_id": "ch_000000",
+            "amount_due": 100,
+            "created": 1558624628,
+            "nickname": "",
+        }
+        actual_payload = StripeInvoicePaymentFailed(
+            self.payment_failed_event
+        ).create_payload()
+
+        assert expected_payload == actual_payload

--- a/src/hub/vendor/invoices.py
+++ b/src/hub/vendor/invoices.py
@@ -6,6 +6,7 @@ import json
 
 from stripe.error import InvalidRequestError
 from stripe import Product
+from typing import Dict, Any
 
 from hub.vendor.abstract import AbstractStripeHubEvent
 from hub.routes.static import StaticRoutes
@@ -16,19 +17,45 @@ logger = get_logger()
 
 
 class StripeInvoicePaymentFailed(AbstractStripeHubEvent):
-    def run(self) -> None:
+    def run(self) -> bool:
+        """
+        Handle Invoice Payment Failed events from Stripe.
+        If the payment failed on subscription_create take no action and :return false
+        Else format data to be sent to Salesforce :return true
+        :return:
+        """
+        logger.info("invoice payment failed event received", payload=self.payload)
+
+        if self.payload.data.object.billing_reason == "subscription_create":
+            logger.info(
+                "invoice payment failed on subscription create - data not sent to external routes"
+            )
+            return False
+
+        data = self.create_payload()
+        logger.info("invoice payment failed", data=data)
+        routes = [StaticRoutes.SALESFORCE_ROUTE]
+        self.send_to_routes(routes, json.dumps(data))
+        return True
+
+    def create_payload(self) -> Dict[str, Any]:
+        """
+        Create payload to be sent to external sources
+        :return payload:
+        :raises InvalidRequestError:
+        """
         try:
             invoice_data = self.payload.data.object.lines.data
-
             product = Product.retrieve(invoice_data[0]["plan"]["product"])
             nickname = format_plan_nickname(
                 product_name=product["name"],
                 plan_interval=invoice_data[0]["plan"]["interval"],
             )
         except InvalidRequestError as e:
+            logger.error("Unable to get plan nickname for payload", error=e)
             nickname = ""
-            logger.error("payment failed error", error=e)
-        data = self.create_data(
+
+        return self.create_data(
             customer_id=self.payload.data.object.customer,
             subscription_id=self.payload.data.object.subscription,
             currency=self.payload.data.object.currency,
@@ -37,6 +64,3 @@ class StripeInvoicePaymentFailed(AbstractStripeHubEvent):
             created=self.payload.data.object.created,
             nickname=nickname,
         )
-        logger.info("invoice payment failed", data=data)
-        routes = [StaticRoutes.SALESFORCE_ROUTE]
-        self.send_to_routes(routes, json.dumps(data))


### PR DESCRIPTION
Added check to ensure invoice payment failure event notifications do not get sent if event is triggered on subscription creation.

https://jira.mozilla.com/browse/COPS-824