### PR TITLE
Added black formatter pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
     -   id: pylint
         additional_dependencies: [pylint-venv]
         args: ['--disable=all']
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    -   id: black
+        language_version: python3.7
 # TODO: Enable in the future as we have issues to address.
 # -   repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
 #     sha: v1.0.3


### PR DESCRIPTION
This pull request (PR) adds a pre-commit hook for running the black formatter on all all changesets prior to committing to git.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/334)
<!-- Reviewable:end -->
