### PR TITLE
Vagrant support for docker and docker-compose.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sudo usermod -a -G docker $USER
 cd /opt/subhub
 pip3 install -r automation_requirements.txt
 python3 dodo.py

--- a/bin/vagrant.sh
+++ b/bin/vagrant.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+cat <<EOT >> ~/.curlrc
+compressed
+fail
+location
+referer = “;auto”
+silent
+show-error
+EOT
+
 sudo apt-get update
 sudo apt-get uninstall -y python
 

--- a/bin/vagrant.sh
+++ b/bin/vagrant.sh
@@ -17,11 +17,26 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 sudo apt-get update
 sudo apt-get install -y yarn
 
+sudo apt -y install apt-transport-https ca-certificates curl software-properties-common
+
+# Install docker engine
+sudo apt-get remove docker docker-engine docker.io containerd runc
+sudo apt-get update
+sudo wget -qO- https://get.docker.com/ | bash
+
+sudo usermod -aG docker vagrant
+sudo systemctl enable docker # Auto-start on boot
+sudo systemctl start docker # Start right now
+
+# Install docker-compose
+curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
 # Install AWSCLI
 sudo apt-get install -y awscli
 
 # Install docker-compose
-sudo curl -L https://github.com/docker/compose/releases/download/1.18.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
 # doit dependency

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -4,6 +4,21 @@
 * Install Virtualbox `brew cask install virtualbox`
 * Install Vagrant `brew cask install vagrant`
 
+## Curl Configuration
+
+The following host level `~/.curlrc` file allows Vagrant to pull from the 
+Ubuntu repositories.
+
+```
+cat ~/.curlrc
+compressed
+fail
+location
+referer = “;auto”
+silent
+show-error
+```
+
 ## Running
 
 * Starting: `vagrant up --provision`


### PR DESCRIPTION
This pull request (PR) provides Vagrant support for docker and docker-compose.  This was used by me for debugging from a non-OSX system, the issues that we faced on master earlier this evening.

Steps to Test:

1. git checkout feature/vagrant-docker-compose
2. vagrant up --provision
3. vagrant ssh
4. cd /opt/subhu
5. python3 dodo.py
6. doit local sub

A sub component should then be up and running in the terminal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/344)
<!-- Reviewable:end -->
