### PR TITLE
Correlation ID to log statements

### DIFF
--- a/src/shared/headers.py
+++ b/src/shared/headers.py
@@ -31,3 +31,11 @@ def dump_safe_headers(request_headers):
             continue
         safe_headers[header_key] = request_headers[header_key]
     return safe_headers
+
+
+def extract_safe(request_headers, key):
+    if request_headers is None:
+        return ""
+    if key in request_headers:
+        return request_headers[key]
+    return ""


### PR DESCRIPTION
This pull request (PR) adds support for sub log statements to contain a correlation identifier based upon an Amazon XRay Trace to be prepended to each log statement.

Steps to Test:

1. `python3 dodo.py`
2. `doit local sub`
3. `curl http://{HOST_IP}:5000/v1/sub/version --header "X-Amzn-Trace-Id: 123"`
4.  Inspect the log files and observe that `correlation_id` is present in all sub component logs.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/348)
<!-- Reviewable:end -->
