### PR TITLE
Deprecated the doit, dynamodb task

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -743,10 +743,3 @@ def task_tidy():
             'find . | grep -E "(__pycache__|\.pyc$)" | xargs rm -rf',
         ]
     }
-
-
-def task_dynamo():
-    return {
-        "task_dep": ["check", "tar"],
-        "actions": [f"env {envs()} docker-compose up dynamodb"],
-    }


### PR DESCRIPTION
This pull request (PR) deprecates the dynamo task for spinning up dynamo individually for testing.  This task was deprecated as part of the dockerization workflow of dynalite.

Steps to Test:

1. git fetch
2. git checkout feature/deprecate-dynamo-task
3. doit dynamo and ensure task does not exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/354)
<!-- Reviewable:end -->
