### PR TITLE
bugfix Customer Subscription Webhooks - Deleted Customer

### DIFF
--- a/src/hub/tests/unit/fixtures/stripe_cust_test1_deleted.json
+++ b/src/hub/tests/unit/fixtures/stripe_cust_test1_deleted.json
@@ -1,0 +1,5 @@
+{
+  "id": "cust_test1",
+  "object": "customer",
+  "deleted": true
+}

--- a/src/hub/tests/unit/stripe/customer/test_stripe_customer.py
+++ b/src/hub/tests/unit/stripe/customer/test_stripe_customer.py
@@ -324,6 +324,10 @@ class StripeCustomerSubscriptionCreatedTest(TestCase):
             cust_no_metadata = json.loads(fh.read())
         self.customer_missing_user = convert_to_stripe_object(cust_no_metadata)
 
+        with open("tests/unit/fixtures/stripe_cust_test1_deleted.json") as fh:
+            cust_test1_deleted = json.loads(fh.read())
+        self.deleted_customer = convert_to_stripe_object(cust_test1_deleted)
+
         with open("tests/unit/fixtures/stripe_prod_test1.json") as fh:
             prod_test1 = json.loads(fh.read())
         self.product = convert_to_stripe_object(prod_test1)
@@ -389,6 +393,14 @@ class StripeCustomerSubscriptionCreatedTest(TestCase):
             StripeCustomerSubscriptionCreated(
                 self.subscription_created_event
             ).get_user_id("cust_123")
+
+    def test_get_user_id_deleted_cust(self):
+        self.mock_customer.return_value = self.deleted_customer
+
+        with self.assertRaises(ClientError):
+            StripeCustomerSubscriptionCreated(
+                self.subscription_created_event
+            ).get_user_id("cust_1")
 
     def test_get_user_id_none_error(self):
         self.mock_customer.return_value = self.customer_missing_user
@@ -494,6 +506,10 @@ class StripeCustomerSubscriptionDeletedTest(TestCase):
             cust_no_metadata = json.loads(fh.read())
         self.customer_missing_user = convert_to_stripe_object(cust_no_metadata)
 
+        with open("tests/unit/fixtures/stripe_cust_test1_deleted.json") as fh:
+            cust_test1_deleted = json.loads(fh.read())
+        self.deleted_customer = convert_to_stripe_object(cust_test1_deleted)
+
         with open("tests/unit/fixtures/stripe_sub_deleted_event.json") as fh:
             self.subscription_deleted_event = json.loads(fh.read())
 
@@ -525,6 +541,14 @@ class StripeCustomerSubscriptionDeletedTest(TestCase):
         ).get_user_id("cust_123")
 
         assert user_id == expected_user_id
+
+    def test_get_user_id_deleted_cust(self):
+        self.mock_customer.return_value = self.deleted_customer
+
+        with self.assertRaises(ClientError):
+            StripeCustomerSubscriptionDeleted(
+                self.subscription_deleted_event
+            ).get_user_id("cust_1")
 
     def test_get_user_id_fetch_error(self):
         self.mock_customer.side_effect = InvalidRequestError(
@@ -579,6 +603,10 @@ class StripeCustomerSubscriptionUpdatedTest(TestCase):
         with open("tests/unit/fixtures/stripe_cust_no_metadata.json") as fh:
             cust_no_metadata = json.loads(fh.read())
         self.customer_missing_user = convert_to_stripe_object(cust_no_metadata)
+
+        with open("tests/unit/fixtures/stripe_cust_test1_deleted.json") as fh:
+            cust_test1_deleted = json.loads(fh.read())
+        self.deleted_customer = convert_to_stripe_object(cust_test1_deleted)
 
         with open("tests/unit/fixtures/stripe_prod_test1.json") as fh:
             prod_test1 = json.loads(fh.read())
@@ -689,6 +717,14 @@ class StripeCustomerSubscriptionUpdatedTest(TestCase):
             StripeCustomerSubscriptionUpdated(
                 self.subscription_updated_event_no_match
             ).get_user_id("cust_123")
+
+    def test_get_user_id_deleted_cust(self):
+        self.mock_customer.return_value = self.deleted_customer
+
+        with self.assertRaises(ClientError):
+            StripeCustomerSubscriptionUpdated(
+                self.subscription_updated_event_no_match
+            ).get_user_id("cust_1")
 
     def test_create_payload_error(self):
         self.mock_product.side_effect = InvalidRequestError(

--- a/src/hub/vendor/customer.py
+++ b/src/hub/vendor/customer.py
@@ -230,14 +230,22 @@ class StripeCustomerSubscriptionCreated(AbstractStripeHubEvent):
         :raises ClientError
         """
         try:
-            updated_customer = vendor.retrieve_stripe_customer(customer_id=customer_id)
-            user_id = updated_customer.metadata.get("userid", None)
+            customer = vendor.retrieve_stripe_customer(customer_id=customer_id)
         except InvalidRequestError as e:
             logger.error("Unable to find customer", error=e)
             raise e
 
+        deleted = customer.get("deleted", False)
+        user_id = None
+        if not deleted:
+            user_id = customer.metadata.get("userid")
+
         if user_id is None:
-            logger.error("customer subscription created - no userid", error=customer_id)
+            logger.error(
+                "customer subscription created - no userid",
+                error=customer_id,
+                is_customer_deleted=deleted,
+            )
             raise ClientError(f"userid is None for customer {customer_id}")
 
         return user_id
@@ -326,14 +334,23 @@ class StripeCustomerSubscriptionDeleted(AbstractStripeHubEvent):
         :raises ClientError
         """
         try:
-            updated_customer = vendor.retrieve_stripe_customer(customer_id=customer_id)
-            user_id = updated_customer.metadata.get("userid", None)
+            customer = vendor.retrieve_stripe_customer(customer_id=customer_id)
+
         except InvalidRequestError as e:
             logger.error("Unable to find customer", error=e)
             raise e
 
+        deleted = customer.get("deleted", False)
+        user_id = None
+        if not deleted:
+            user_id = customer.metadata.get("userid")
+
         if user_id is None:
-            logger.error("customer subscription deleted - no userid", error=customer_id)
+            logger.error(
+                "customer subscription deleted - no userid",
+                error=customer_id,
+                is_customer_deleted=deleted,
+            )
             raise ClientError(f"userid is None for customer {customer_id}")
 
         return user_id
@@ -413,14 +430,22 @@ class StripeCustomerSubscriptionUpdated(AbstractStripeHubEvent):
         :raises ClientError
         """
         try:
-            updated_customer = vendor.retrieve_stripe_customer(customer_id=customer_id)
-            user_id = updated_customer.metadata.get("userid", None)
+            customer = vendor.retrieve_stripe_customer(customer_id=customer_id)
         except InvalidRequestError as e:
             logger.error("Unable to find customer", error=e)
             raise e
 
+        deleted = customer.get("deleted", False)
+        user_id = None
+        if not deleted:
+            user_id = customer.metadata.get("userid")
+
         if user_id is None:
-            logger.error("customer subscription updated - no userid", error=customer_id)
+            logger.error(
+                "customer subscription updated - no userid",
+                error=customer_id,
+                is_customer_deleted=deleted,
+            )
             raise ClientError(f"userid is None for customer {customer_id}")
 
         return user_id


### PR DESCRIPTION
We were encountering 500 errors on some Customer Subscription Deleted events. When investigating, the fetch Customer calls were returning 200s, but there was a distinct possibility that the Customer record being returned was for a deleted entity, which would result in a failed attempt to create the payload. I added checks to verify if a Customer has been deleted to the get_user_id methods and added addtional logging information. These deleted Customer checks have been added to all of the subscription events.