### PR TITLE
Enable bandit vunerability check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,9 @@ repos:
     hooks:
     -   id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
-# TODO: Enable in the future as we have issues to address.
-# -   repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-#     sha: v1.0.3
-#     hooks:
-#     -   id: python-bandit-vulnerability-check
+-   repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
+    sha: v1.0.3
+    hooks:
+    -   id: python-bandit-vulnerability-check
+        args: [-l, --recursive, -x, tests]
+        files: .py$


### PR DESCRIPTION
This pull request re-enables the prior Bandit security check that we introduced previously.  The prior issues have been rectified.

Steps to Test:

1. git fetch
2. git checkout feature/enable-bandit
3. pre-commit and then verify the `bandit` stage

```
vagrant@ubuntu-xenial:/opt/subhub$ pre-commit
[WARNING] Unexpected key(s) present on https://github.com/Lucas-C/pre-commit-hooks-bandit: sha
Check for added large files..........................(no files to check)Skipped
Check JSON...........................................(no files to check)Skipped
Detect Private Key...................................(no files to check)Skipped
Fix End of Files.....................................(no files to check)Skipped
Pretty format JSON...................................(no files to check)Skipped
Trim Trailing Whitespace.............................(no files to check)Skipped
Check hooks apply to the repository..................(no files to check)Skipped
Check for useless excludes...........................(no files to check)Skipped
pylint...............................................(no files to check)Skipped
black................................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
bandit...............................................(no files to check)Skipped
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/358)
<!-- Reviewable:end -->
