### PR TITLE
Deprecate unused mypy task

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -34,7 +34,6 @@ NEWLINE = "\n"
 VENV = f"{CFG.REPO_ROOT}/venv"
 PYTHON3 = f"{VENV}/bin/python3.7"
 PIP3 = f"{PYTHON3} -m pip"
-MYPY = f"{VENV}/bin/mypy"
 NODE_MODULES = f"{CFG.REPO_ROOT}/node_modules"
 SLS = f"{NODE_MODULES}/serverless/bin/serverless"
 SVCS = [
@@ -501,33 +500,13 @@ def task_perf_remote():
     }
 
 
-@skip("mypy")
-def task_mypy():
-    """
-    run mpyp, a static type checker for Python 3
-    """
-    for pkg in ("sub", "hub"):
-        yield {
-            "name": pkg,
-            "task_dep": ["check", "yarn", "venv"],
-            "actions": [
-                f"cd {CFG.REPO_ROOT}/src && env {envs(MYPYPATH=VENV)} {MYPY} -p {pkg}"
-            ],
-        }
-
-
 @skip("test")
 def task_test():
     """
     run tox in tests/
     """
     return {
-        "task_dep": [
-            "check",
-            "yarn",
-            "venv",
-            #'mypy', FIXME: this needs to be activated once mypy is figured out
-        ],
+        "task_dep": ["check", "yarn", "venv",],
         "actions": [f"cd {CFG.REPO_ROOT} && tox"],
     }
 


### PR DESCRIPTION
This pull request deprecates an unused doit task that may have been used at some point (unknown to me).  Instead this was replaced with a pre-commit hook along with an updated configuration in a prior pull request.

Steps to Test:

1. git fetch
2. git checkout feature/deprecate-doit-mypy
3. doit mypy then assert no such task exists

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/361)
<!-- Reviewable:end -->
