### PR TITLE
Deprecate yarn on test task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,5 +44,5 @@ repos:
     sha: v1.0.3
     hooks:
     -   id: python-bandit-vulnerability-check
-        args: [-l, --recursive, -x, tests]
+        args: [-l, --recursive, -x, tests, --skip, "B101,B106,B404"]
         files: .py$

--- a/dodo.py
+++ b/dodo.py
@@ -516,7 +516,7 @@ def task_test():
     run tox in tests/
     """
     return {
-        "task_dep": ["check", "yarn", "venv",],
+        "task_dep": ["check", "venv",],
         "actions": [f"cd {CFG.REPO_ROOT} && tox"],
     }
 


### PR DESCRIPTION
This pull request (PR) deprecates the `yarn` install stage from the doit test task.  This is not longer required as the `dynalite` dependency has been eliminated.  There is a change required by Bandit here.  These changes are related to the `--skips` in the pre-commit hook.  A handful of vulnerabilities of low risk were identified and added to be skipped.  More information on those can be see in the README file located [here](https://github.com/PyCQA/bandit#exclusions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/371)
<!-- Reviewable:end -->
