### PR TITLE
Only run black formatter on all of the code but one file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     hooks:
     -   id: black
         language_version: python3.7
+        exclude: dodo.py
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.740
     hooks:


### PR DESCRIPTION
This pull request (PR) runs the black formatter on the entire codebase with the exception of 1 non-standard excluded directory or file that black ships with.  Those are:

- .eggs
- .git
- .hg 
- .mypy
-  _cache 
- .nox
- .tox
- .venv
- _build
- buck-out
- build
- dist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/372)
<!-- Reviewable:end -->
