### PR TITLE
Added license header pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,32 @@ repos:
     -   id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
 -   repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-    sha: v1.0.3
+    rev: v1.0.3
     hooks:
     -   id: python-bandit-vulnerability-check
         args: [-l, --recursive, -x, tests, --skip, "B101,B106,B404"]
         files: .py$
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.7
+    hooks:
+    -   id: insert-license
+        files: \.py
+        args:
+        - --license-filepath
+        - etc/license-header
+        - --comment-style
+    -   id: insert-license
+        files: \.yml
+        args:
+        - --license-filepath
+        - etc/license-header
+    -   id: insert-license
+        files: \.txt
+        args:
+        - --license-filepath
+        - etc/license-header
+    -   id: insert-license
+        files: \.ini
+        args:
+        - --license-filepath
+        - etc/license-header

--- a/etc/license-header
+++ b/etc/license-header
@@ -1,0 +1,3 @@
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
This pull request (PR) adds pre-commit support for adding license headers to the following file types if it was forgotten during the development process:

* Python
* Text
* YAML
* Ini configuration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/375)
<!-- Reviewable:end -->
