### PR TITLE
Defect: license file header for Python files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,6 @@ repos:
         args:
         - --license-filepath
         - etc/license-header
-        - --comment-style
     -   id: insert-license
         files: \.yml
         args:


### PR DESCRIPTION
This pull request (PR) corrects an issue that appears to be incurred from a merge conflict in a prior work.  This defect resolves an issue in which if a Python file is staged in git, the file when the pre-commit hook is executed, will prepend the source path instead of using the comment character.

Steps to Test:

1. Add a Python file to the code base with valid content
2. git add -A
3. git commit -m "This is just a test"
4. Observe the MPL license header is added to the file correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/381)
<!-- Reviewable:end -->
