### PR TITLE
feature: added next_invoice_date support

### DIFF
--- a/src/hub/tests/unit/stripe/customer/test_stripe_customer.py
+++ b/src/hub/tests/unit/stripe/customer/test_stripe_customer.py
@@ -345,24 +345,28 @@ class StripeCustomerSubscriptionCreatedTest(TestCase):
         customer_patcher = patch("stripe.Customer.retrieve")
         product_patcher = patch("stripe.Product.retrieve")
         invoice_patcher = patch("stripe.Invoice.retrieve")
+        preview_invoice_patcher = patch("stripe.Invoice.upcoming")
         charge_patcher = patch("stripe.Charge.retrieve")
         run_pipeline_patcher = patch("hub.routes.pipeline.AllRoutes.run")
 
         self.addCleanup(customer_patcher.stop)
         self.addCleanup(product_patcher.stop)
         self.addCleanup(invoice_patcher.stop)
+        self.addCleanup(preview_invoice_patcher.stop)
         self.addCleanup(charge_patcher.stop)
         self.addCleanup(run_pipeline_patcher.stop)
 
         self.mock_customer = customer_patcher.start()
         self.mock_product = product_patcher.start()
         self.mock_invoice = invoice_patcher.start()
+        self.mock_preview_invoice = preview_invoice_patcher.start()
         self.mock_charge = charge_patcher.start()
         self.mock_run_pipeline = run_pipeline_patcher.start()
 
     def test_run(self):
         self.mock_customer.return_value = self.customer
         self.mock_invoice.return_value = self.invoice
+        self.mock_preview_invoice.return_value = self.invoice
         self.mock_charge.return_value = self.charge
         self.mock_product.return_value = self.product
         self.mock_run_pipeline = None
@@ -413,6 +417,7 @@ class StripeCustomerSubscriptionCreatedTest(TestCase):
         self.mock_invoice.return_value = self.invoice
         self.mock_charge.return_value = self.charge
         self.mock_product.return_value = self.product
+        self.mock_preview_invoice.return_value = self.invoice
 
         user_id = "user123"
 
@@ -439,6 +444,7 @@ class StripeCustomerSubscriptionCreatedTest(TestCase):
             currency="usd",
             current_period_start=1519435009,
             current_period_end=1521854209,
+            next_invoice_date=1555354567,
             invoice_number="3B74E3D0-0001",
             brand="Visa",
             last4="0019",
@@ -698,6 +704,7 @@ class StripeCustomerSubscriptionUpdatedTest(TestCase):
         self.mock_customer.return_value = self.customer
         self.mock_product.return_value = self.product
         self.mock_invoice.return_value = self.invoice
+        self.mock_upcoming_invoice.return_value = self.invoice
         self.mock_charge.return_value = self.charge
         self.mock_run_pipeline.return_value = None
 
@@ -796,6 +803,7 @@ class StripeCustomerSubscriptionUpdatedTest(TestCase):
         self.mock_product.return_value = self.product
         self.mock_invoice.return_value = self.invoice
         self.mock_charge.return_value = self.charge
+        self.mock_upcoming_invoice.return_value = self.invoice
 
         user_id = "user123"
         event_name = "customer.recurring_charge"
@@ -813,6 +821,7 @@ class StripeCustomerSubscriptionUpdatedTest(TestCase):
             cancel_at_period_end=False,
             current_period_start=1571949971,
             current_period_end=1572036371,
+            next_invoice_date=1555354567,
             invoice_id="in_1FXDCFJNcmPzuWtRT9U5Xvcz",
             active=True,
             subscriptionId="sub_FCUzkHmNY3Mbj1",  # required by FxA

--- a/src/hub/vendor/customer.py
+++ b/src/hub/vendor/customer.py
@@ -280,6 +280,12 @@ class StripeCustomerSubscriptionCreated(AbstractStripeHubEvent):
                 plan_interval=self.payload.data.object.plan.interval,
             )
 
+            next_invoice = vendor.retrieve_stripe_invoice_upcoming_by_subscription(
+                customer_id=self.payload.data.object.customer,
+                subscription_id=self.payload.data.object.id,
+            )
+            next_invoice_date = next_invoice.get("period_start", 0)
+
             return self.create_data(
                 uid=user_id,
                 active=self.is_active_or_trialing,
@@ -301,6 +307,7 @@ class StripeCustomerSubscriptionCreated(AbstractStripeHubEvent):
                 currency=self.payload.data.object.plan.currency,
                 current_period_start=self.payload.data.object.current_period_start,
                 current_period_end=self.payload.data.object.current_period_end,
+                next_invoice_date=next_invoice_date,
                 invoice_number=invoice_number,
                 brand=brand,
                 last4=last4,
@@ -557,12 +564,19 @@ class StripeCustomerSubscriptionUpdated(AbstractStripeHubEvent):
         logger.info("latest invoice", latest_invoice=latest_invoice)
         logger.info("latest charge", latest_charge=latest_charge)
 
+        next_invoice = vendor.retrieve_stripe_invoice_upcoming_by_subscription(
+            customer_id=self.payload.data.object.customer,
+            subscription_id=self.payload.data.object.id,
+        )
+        next_invoice_date = next_invoice.get("period_start", 0)
+
         return dict(
             canceled_at=self.payload.data.object.canceled_at,
             cancel_at=self.payload.data.object.cancel_at,
             cancel_at_period_end=self.payload.data.object.cancel_at_period_end,
             current_period_start=self.payload.data.object.current_period_start,
             current_period_end=self.payload.data.object.current_period_end,
+            next_invoice_date=next_invoice_date,
             invoice_id=self.payload.data.object.latest_invoice,
             active=self.is_active_or_trialing,
             subscriptionId=self.payload.data.object.id,  # required by FxA


### PR DESCRIPTION
Added next_invoice_date information to the create subscription and recurring invoice payloads that are sent to Salesforce

https://jira.mozilla.com/browse/COPS-903