### PR TITLE
Removed Bandit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,15 +43,9 @@ repos:
     -   id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
 -   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    sha: v1.1.0
+    rev: v1.1.0
     hooks:
     -   id: python-safety-dependencies-check
--   repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-    rev: v1.0.3
-    hooks:
-    -   id: python-bandit-vulnerability-check
-        args: [-l, --recursive, -x, tests, --skip, "B101,B106,B404"]
-        files: .py$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.7
     hooks:


### PR DESCRIPTION
This pull request (PR) removes the git pre-commit hook, bandit.  Bandit is a code quality tool established by the Python Code Quality Authority (PCQA), [here](https://github.com/PyCQA) for analysis of security vulnerabilities such as [shell injection](https://security.openstack.org/guidelines/dg_avoid-shell-true.html) that was found in the `dodo.py` file in this repository.  

The PCQA organization is responsible for bringing your software such as:
- pylint
- pydocstyle
- pyflakes
- flake8
- meta

I added these references as it bandit was mentioned by some as potentially untested software.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/396)
<!-- Reviewable:end -->
