### PR TITLE
Update bandit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,12 +46,10 @@ repos:
     sha: v1.1.0
     hooks:
     -   id: python-safety-dependencies-check
--   repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-    rev: v1.0.3
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.6.2
     hooks:
-    -   id: python-bandit-vulnerability-check
-        args: [-l, --recursive, -x, tests, --skip, "B101,B106,B404"]
-        files: .py$
+    -   id: bandit
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.7
     hooks:


### PR DESCRIPTION
This pull request (PR) adds support for the latest bandit pre-commit hook which moved to a new pre-commit repo location from the original.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/399)
<!-- Reviewable:end -->
