### PR TITLE
Handle invalid change object identifiers

### DIFF
--- a/src/shared/tests/unit/fixtures/stripe_ch_test2.json
+++ b/src/shared/tests/unit/fixtures/stripe_ch_test2.json
@@ -1,0 +1,143 @@
+{
+    "id": "",
+    "object": "charge",
+    "amount": 1000,
+    "amount_refunded": 0,
+    "application": null,
+    "application_fee": null,
+    "application_fee_amount": null,
+    "balance_transaction": "txn_1FCyC5JNcmPzuWtRZVJ3VRLC",
+    "billing_details": {
+        "address": {
+            "city": null,
+            "country": null,
+            "line1": null,
+            "line2": null,
+            "postal_code": null,
+            "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+    },
+    "captured": false,
+    "created": 1558033578,
+    "currency": "usd",
+    "customer": "cus_F4yl2VV15h6ahh",
+    "description": "Payment for invoice 1D1C1268-0002",
+    "destination": null,
+    "dispute": null,
+    "failure_code": "card_declined",
+    "failure_message": "Your card was declined.",
+    "fraud_details": {
+        "stripe_report": "fraudulent"
+    },
+    "invoice": "in_1EaouDJNcmPzuWtReWEFz6j0",
+    "livemode": false,
+    "metadata": {},
+    "on_behalf_of": null,
+    "order": null,
+    "outcome": {
+        "network_status": "not_sent_to_network",
+        "reason": "merchant_blacklist",
+        "risk_level": "highest",
+        "risk_score": 76,
+        "seller_message": "Stripe blocked this payment.",
+        "type": "blocked"
+    },
+    "paid": false,
+    "payment_intent": "pi_1EaouDJNcmPzuWtRSbo5ntSi",
+    "payment_method": "card_1EaosmJNcmPzuWtRa3ygzXId",
+    "payment_method_details": {
+        "card": {
+            "brand": "visa",
+            "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+            },
+            "country": "US",
+            "exp_month": 12,
+            "exp_year": 2023,
+            "fingerprint": "bMt3PVLFsmMUsiqx",
+            "funding": "credit",
+            "last4": "0019",
+            "three_d_secure": {
+                "authenticated": false,
+                "succeeded": true,
+                "version": "1.0"
+            },
+            "wallet": null
+        },
+        "type": "card"
+    },
+    "receipt_email": null,
+    "receipt_number": null,
+    "receipt_url": "https://pay.stripe.com/receipts/acct_1EJOaaJNcmPzuWtR/ch_1EaouEJNcmPzuWtRIabj08KN/rcpt_F4yrXrJVsUxcXUB932zUcgWhpkNOIDM",
+    "refunded": false,
+    "refunds": {
+        "object": "list",
+        "data": [],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges/ch_1EaouEJNcmPzuWtRIabj08KN/refunds"
+    },
+    "review": null,
+    "shipping": null,
+    "source": {
+        "id": "src_1EaouDJNcmPzuWtRpQanmuk9",
+        "object": "source",
+        "amount": 1000,
+        "client_secret": "src_client_secret_F4yreVQ0YNwEjJ5TKFLQbDpe",
+        "created": 1558033578,
+        "currency": "usd",
+        "flow": "redirect",
+        "livemode": false,
+        "metadata": {},
+        "owner": {
+            "address": null,
+            "email": null,
+            "name": null,
+            "phone": null,
+            "verified_address": null,
+            "verified_email": null,
+            "verified_name": null,
+            "verified_phone": null
+        },
+        "redirect": {
+            "failure_reason": null,
+            "return_url": "stripejs://use_stripe_sdk/return_url",
+            "status": "not_required",
+            "url": "https://hooks.stripe.com/redirect/authenticate/src_1EaouDJNcmPzuWtRpQanmuk9?client_secret=src_client_secret_F4yreVQ0YNwEjJ5TKFLQbDpe"
+        },
+        "statement_descriptor": null,
+        "status": "consumed",
+        "three_d_secure": {
+            "card": "card_1EaosmJNcmPzuWtRa3ygzXId",
+            "exp_month": 12,
+            "exp_year": 2023,
+            "last4": "0019",
+            "country": "US",
+            "brand": "Visa",
+            "cvc_check": "unavailable",
+            "funding": "credit",
+            "fingerprint": "bMt3PVLFsmMUsiqx",
+            "three_d_secure": "optional",
+            "customer": null,
+            "authenticated": false,
+            "name": null,
+            "address_line1_check": null,
+            "address_zip_check": null,
+            "tokenization_method": null,
+            "dynamic_last4": null
+        },
+        "type": "three_d_secure",
+        "usage": "single_use"
+    },
+    "source_transfer": null,
+    "statement_descriptor": null,
+    "statement_descriptor_suffix": null,
+    "status": "failed",
+    "transfer_data": null,
+    "transfer_group": null
+}

--- a/src/shared/tests/unit/test_vendor.py
+++ b/src/shared/tests/unit/test_vendor.py
@@ -45,7 +45,7 @@ class TestStripeCustomerCalls(TestCase):
     def test_create_success(self):
         self.create_customer_mock.side_effect = [APIError("message"), self.customer]
 
-        customer = vendor.create_stripe_customer(
+        customer = vendor.create_stripe_customer(  # nosec
             source_token="token",
             email="user@example.com",
             userid="user_123",
@@ -53,13 +53,13 @@ class TestStripeCustomerCalls(TestCase):
             idempotency_key=utils.get_indempotency_key(),
         )
 
-        assert customer == self.customer
+        assert customer == self.customer  # nosec
 
     def test_create_error(self):
         self.create_customer_mock.side_effect = APIError("message")
 
         with self.assertRaises(APIError):
-            vendor.create_stripe_customer(
+            vendor.create_stripe_customer(  # nosec
                 source_token="token",
                 email="user@example.com",
                 userid="user_123",
@@ -72,7 +72,7 @@ class TestStripeCustomerCalls(TestCase):
 
         customer = vendor.retrieve_stripe_customer(customer_id="cust_123")
 
-        assert customer == self.customer
+        assert customer == self.customer  # nosec
 
     def test_retrieve_error(self):
         self.retrieve_customer_mock.side_effect = APIError("message")
@@ -85,7 +85,7 @@ class TestStripeCustomerCalls(TestCase):
 
         customer_list = vendor.get_customer_list("user@example.com")
 
-        assert customer_list == [self.customer]
+        assert customer_list == [self.customer]  # nosec
 
     def test_list_error(self):
         self.list_customer_mock.side_effect = APIError("message")
@@ -96,19 +96,19 @@ class TestStripeCustomerCalls(TestCase):
     def test_modify_success(self):
         self.modify_customer_mock.side_effect = [APIError("message"), self.customer]
 
-        customer = vendor.modify_customer(
+        customer = vendor.modify_customer(  # nosec
             customer_id="cust_123",
             source_token="token",
             idempotency_key=utils.get_indempotency_key(),
         )
 
-        assert customer == self.customer
+        assert customer == self.customer  # nosec
 
     def test_modify_error(self):
         self.modify_customer_mock.side_effect = APIError("message")
 
         with self.assertRaises(APIError):
-            vendor.modify_customer(
+            vendor.modify_customer(  # nosec
                 customer_id="cust_123",
                 source_token="token",
                 idempotency_key=utils.get_indempotency_key(),
@@ -122,7 +122,7 @@ class TestStripeCustomerCalls(TestCase):
 
         deleted_customer = vendor.delete_stripe_customer(customer_id="cust_123")
 
-        assert deleted_customer == self.deleted_customer
+        assert deleted_customer == self.deleted_customer  # nosec
 
     def test_delete_error(self):
         self.delete_customer_mock.side_effect = APIError("message")
@@ -176,7 +176,7 @@ class TestStripeSubscriptionCalls(TestCase):
             idempotency_key=utils.get_indempotency_key(),
         )
 
-        assert subscription == self.subscription
+        assert subscription == self.subscription  # nosec
 
     def test_build_error(self):
         self.mock_create_subscription.side_effect = APIError("message")
@@ -198,7 +198,7 @@ class TestStripeSubscriptionCalls(TestCase):
             plan_id="plan_123",
             idempotency_key=utils.get_indempotency_key(),
         )
-        assert subscription == self.subscription
+        assert subscription == self.subscription  # nosec
 
     def test_update_error(self):
         self.mock_modify_subscription.side_effect = APIError("message")
@@ -220,7 +220,7 @@ class TestStripeSubscriptionCalls(TestCase):
             subscription_id="sub_123", idempotency_key=utils.get_indempotency_key()
         )
 
-        assert subscription == self.subscription
+        assert subscription == self.subscription  # nosec
 
     def test_cancel_at_end_error(self):
         self.mock_modify_subscription.side_effect = APIError("message")
@@ -240,7 +240,7 @@ class TestStripeSubscriptionCalls(TestCase):
             subscription_id="sub_123", idempotency_key=utils.get_indempotency_key()
         )
 
-        assert subscription == self.subscription
+        assert subscription == self.subscription  # nosec
 
     def test_cancel_immediately_error(self):
         self.mock_delete_subscription.side_effect = APIError("message")
@@ -260,7 +260,7 @@ class TestStripeSubscriptionCalls(TestCase):
             subscription_id="sub_123", idempotency_key=utils.get_indempotency_key()
         )
 
-        assert subscription == self.subscription
+        assert subscription == self.subscription  # nosec
 
     def test_reactivate_error(self):
         self.mock_modify_subscription.side_effect = APIError("message")
@@ -275,7 +275,7 @@ class TestStripeSubscriptionCalls(TestCase):
 
         subscription_list = vendor.list_customer_subscriptions(cust_id="cust_123")
 
-        assert subscription_list == self.list
+        assert subscription_list == self.list  # nosec
 
     def test_list_error(self):
         self.mock_list_subscription.side_effect = APIError("message")
@@ -290,6 +290,10 @@ class TestStripeChargeCalls(TestCase):
             charge = json.loads(fh.read())
         self.charge = convert_to_stripe_object(charge)
 
+        with open(os.path.join(DIRECTORY, "fixtures/stripe_ch_test2.json")) as fh:
+            charge2 = json.loads(fh.read())
+        self.charge2 = convert_to_stripe_object(charge)
+
         retrieve_charge_patcher = patch("stripe.Charge.retrieve")
         self.addCleanup(retrieve_charge_patcher.stop)
         self.retrieve_charge_mock = retrieve_charge_patcher.start()
@@ -298,7 +302,13 @@ class TestStripeChargeCalls(TestCase):
         self.retrieve_charge_mock.side_effect = [APIError("message"), self.charge]
 
         charge = vendor.retrieve_stripe_charge("in_test1")
-        assert charge == self.charge
+        assert charge == self.charge  # nosec
+
+    def test_retrieve_no_charge_id(self):
+        self.retrieve_charge_mock.side_effect = [APIError("message"), self.charge2]
+
+        charge = vendor.retrieve_stripe_charge("in_test1")
+        assert charge == self.charge2  # nosec
 
     def test_retrieve_error(self):
         self.retrieve_charge_mock.side_effect = APIError("message")
@@ -326,7 +336,7 @@ class TestStripeInvoiceCalls(TestCase):
         self.retrieve_invoice_mock.side_effect = [APIError("message"), self.invoice]
 
         invoice = vendor.retrieve_stripe_invoice("in_test1")
-        assert invoice == self.invoice
+        assert invoice == self.invoice  # nosec
 
     def test_retrieve_error(self):
         self.retrieve_invoice_mock.side_effect = APIError("message")
@@ -340,7 +350,7 @@ class TestStripeInvoiceCalls(TestCase):
         invoice = vendor.retrieve_stripe_invoice_upcoming_by_subscription(
             customer_id="cust_123", subscription_id="sub_123"
         )
-        assert invoice == self.invoice
+        assert invoice == self.invoice  # nosec
 
     def test_upcoming_by_subscription_error(self):
         self.preview_invoice_mock.side_effect = APIError("message")
@@ -354,7 +364,7 @@ class TestStripeInvoiceCalls(TestCase):
         self.preview_invoice_mock.return_value = self.invoice
 
         invoice = vendor.retrieve_stripe_invoice_upcoming(customer="cust_123")
-        assert invoice == self.invoice
+        assert invoice == self.invoice  # nosec
 
     def test_upcoming_error(self):
         self.preview_invoice_mock.side_effect = APIError("message")
@@ -382,7 +392,7 @@ class TestStripePlanCalls(TestCase):
         self.list_plan_mock.side_effect = [APIError("message"), self.plan_list]
 
         plan_list = vendor.retrieve_plan_list(1)
-        assert plan_list == self.plan_list
+        assert plan_list == self.plan_list  # nosec
 
     def test_retrieve_list_error(self):
         self.list_plan_mock.side_effect = APIError("message")
@@ -395,7 +405,7 @@ class TestStripePlanCalls(TestCase):
 
         plan = vendor.retrieve_stripe_plan("plan_test1")
 
-        assert plan == self.plan
+        assert plan == self.plan  # nosec
 
     def test_retrieve_error(self):
         self.retrieve_plan_mock.side_effect = InvalidRequestError(
@@ -424,7 +434,7 @@ class TestStripeProductCalls(TestCase):
 
         product = vendor.retrieve_stripe_product("prod_test1")
 
-        assert product == self.product
+        assert product == self.product  # nosec
 
     def test_retrieve_error(self):
         self.retrieve_product_mock.side_effect = InvalidRequestError(

--- a/src/shared/vendor.py
+++ b/src/shared/vendor.py
@@ -392,20 +392,26 @@ def retrieve_stripe_charge(charge_id: str) -> Charge:
     :param charge_id:
     :return: Charge
     """
-    try:
-        charge = Charge.retrieve(charge_id)
-        logger.debug("retrieve stripe charge", charge=charge)
-        return charge
-    except (
-        InvalidRequestError,
-        APIConnectionError,
-        APIError,
-        RateLimitError,
-        IdempotencyError,
-        StripeErrorWithParamCode,
-    ) as e:
-        logger.error("retrieve stripe error", error=str(e))
-        raise e
+    if charge_id is None:
+        logger.error(
+            "hub::shared::vendor::retrieve_stripe_charge received a None charge_id, ignoring."
+        )
+        return None
+    else:
+        try:
+            charge = Charge.retrieve(charge_id)
+            logger.debug("retrieve stripe charge", charge=charge)
+            return charge
+        except (
+            InvalidRequestError,
+            APIConnectionError,
+            APIError,
+            RateLimitError,
+            IdempotencyError,
+            StripeErrorWithParamCode,
+        ) as e:
+            logger.error("retrieve stripe error", error=str(e))
+            raise e
 
 
 # end Charge calls


### PR DESCRIPTION
This pull request provides logging for when a call is made with an invalid charge_id.  This can occur in some edge cases as we have observed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/421)
<!-- Reviewable:end -->
