### PR TITLE
COPS-965: Remove NewRelic Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Payment subscription REST api for customers:
 
 ### [AWS DynamoDB Backups](./docs/backups.md)
 
-### [NewRelic - AWS Lambda Integration](./bin/new-relic/README.md)
-
 ### [Vagrant support to replicate TravisCI](./docs/vagrant.md)
 
 ### [Code of Conduct](./CODE_OF_CONDUCT.md)

--- a/services/fxa/hubhandler.py
+++ b/services/fxa/hubhandler.py
@@ -16,7 +16,6 @@ serverless_wsgi.TEXT_MIME_TYPES.append("application/custom+json")
 # the AWS environment
 sys.path.insert(0, join(dirname(realpath(__file__)), "src"))
 
-
 from aws_xray_sdk.core import xray_recorder, patch_all
 from aws_xray_sdk.core.context import Context
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware


### PR DESCRIPTION
This pull request (PR) removes support for streaming to NewRelic for all components.  I will provide a subsequent PR for adding support for Sentry.  We have setup a Sentry project for subhub already for this purpose.  This also allows for a cost reduction by moving from NewRelic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/461)
<!-- Reviewable:end -->
