### PR TITLE
Coerce Stripe API to never log below ERROR log levels

### DIFF
--- a/src/shared/log.py
+++ b/src/shared/log.py
@@ -26,6 +26,7 @@ dict_config = {
     "loggers": {
         "": {"handlers": ["json"], "level": CFG.LOG_LEVEL},
         "werkzeug": {"level": "ERROR", "handlers": ["json"], "propagate": False},
+        "stripe": {"level": "ERROR", "handlers": ["json"], "propagate": False},
         "pytest": {"level": "ERROR", "handlers": ["json"], "propagate": False},
         "pynamodb": {"level": "ERROR", "handlers": ["json"], "propagate": False},
         "botocore": {"level": "ERROR", "handlers": ["json"], "propagate": False},


### PR DESCRIPTION
This change forces Stripe to only log at the ERROR level and thus will not allow for leaking of Stripe tokens or headers to the log file.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/subhub/474)
<!-- Reviewable:end -->
